### PR TITLE
remove unneeded mysql gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :deployment do
 end
 
 group :staging, :production, :development do
-  gem 'mysql'
   gem 'mysql2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,6 @@ GEM
       nom-xml (~> 0.5.2)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    mysql (2.9.1)
     mysql2 (0.3.18)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -326,7 +325,6 @@ DEPENDENCIES
   jquery-rails
   launchy
   meta_request
-  mysql
   mysql2
   parallel
   rails (>= 4.1.6)
@@ -350,4 +348,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.4
+   1.12.5


### PR DESCRIPTION
This PR removes the `mysql` gem from `Gemfile`. `mysql2` should be sufficient.