### PR TITLE
remove fetcher dependency on ApplicationHelper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,0 @@
-module ApplicationHelper
-  def yTenK
-    '9999-12-31T23:59:59Z'
-  end
-end

--- a/lib/fetcher.rb
+++ b/lib/fetcher.rb
@@ -2,7 +2,8 @@ require 'active_support/inflector'
 
 # A mixin module that is part of application controller, this provides base functionality to all classes
 module Fetcher
-  include ApplicationHelper
+
+  Y_TEN_K = '9999-12-31T23:59:59Z'.freeze
 
   # Run a solr query, and do some logging
   # @param params [Hash] params to send to solr
@@ -94,7 +95,7 @@ module Fetcher
   def get_times(p = {})
     params = p || {}
     first_modified = params[:first_modified] || Time.zone.at(0).iso8601
-    last_modified = params[:last_modified] || yTenK
+    last_modified = params[:last_modified] || Y_TEN_K
     begin
       first_modified_time = Time.zone.parse(first_modified).iso8601
       last_modified_time = Time.zone.parse(last_modified).iso8601

--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -8,7 +8,6 @@ require 'squash/rails'
 require 'action_controller'
 
 module Indexer
-  include ApplicationHelper
   include Squash::Ruby::ControllerMethods
 
   @@indexer_config = PurlFetcher::Application.config.solr_indexing

--- a/spec/features/fetcher_spec.rb
+++ b/spec/features/fetcher_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 describe('Fetcher lib') do
-  include ApplicationHelper
-
   let(:fetcher) { FetcherTester.new }
   let(:earliest) { '1970-01-01T00:00:00Z' }
-  let(:latest) { yTenK }
+  let(:latest) { Fetcher::Y_TEN_K }
 
   it 'lets us know if the user only wants registered items' do
     expect(fetcher.registered_only?(nil)).to be false
@@ -89,7 +87,7 @@ describe('Fetcher lib') do
   end
 
   it 'raises an error when selected for an invalid date range' do
-    times = { first: yTenK, last: yTenK }
+    times = { first: Fetcher::Y_TEN_K, last: Fetcher::Y_TEN_K }
     last_changed = ['2014-05-05T05:04:13Z', '2014-04-05T05:04:13Z']
     expect{ fetcher.determine_latest_date(times, last_changed) }.to raise_error(RuntimeError)
   end

--- a/spec/features/indexer_spec.rb
+++ b/spec/features/indexer_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe('Indexer lib') do
-  include ApplicationHelper
 
   let(:indexer) { IndexerTester.new }
   let(:sample_doc_path) { DruidTools::PurlDruid.new('bb050dj7711', testing_doc_cache).path }


### PR DESCRIPTION
These should really be for views. No need to have helpers shared with a controller mixin module. Anyways this should be a static.