### PR TITLE
rspec is optional on deployed machines

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,14 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:rspec)
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:rspec)
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # ignore in non-test environments
+end
 
 Rails.application.load_tasks


### PR DESCRIPTION
This PR changes the Gemfile such that `rspec` is optional. Otherwise it breaks the `Rakefile` on deployed machines... is connected to #30 