### PR TITLE
relocate server declaration to config/deploy.rb with standard suffix

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,3 +19,6 @@ set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public
 
 # Default value for keep_releases is 5
 set :keep_releases, 5
+
+# server uses standardized suffix
+server "purl-fetcher-#{fetch(:stage)}.stanford.edu", user: fetch(:user), roles: %w{web db app}

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,4 +1,3 @@
-server 'purl-fetcher-dev.stanford.edu', user: fetch(:user), roles: %w{web db app}
 set :bundle_without, %w(test deployment development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,3 @@
-server 'purl-fetcher-prod.stanford.edu', user: fetch(:user), roles: %w{web db app}
 set :bundle_without, %w(test deployment development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,4 +1,3 @@
-server 'purl-fetcher-stage.stanford.edu', user: fetch(:user), roles: %w{web db app}
 set :bundle_without, %w(test deployment development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This PR consolidates the `server` directive into the main `config/deploy.rb` configuration. Is connected to #30 