### PR TITLE
fix /docs routes to be GET only

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -1,11 +1,6 @@
 class DocsController < ApplicationController
   include Indexer
 
-  # Stub function that renders 'ok' when index is called.  Under the current spec, this should never be called.
-  def index
-    render_result('ok')
-  end
-
   # API call to get a full list of all solr documents modified between two times
   # @param [querystring] Parameters can be specified in the querystring
   #   * first_modified = datetime in UTC (default: earliest possible date)
@@ -30,10 +25,5 @@ class DocsController < ApplicationController
   def deletes
     result = get_deletes_list_from_solr(first_modified: params['first_modified'], last_modified: params['last_modified'])
     render_result(result)
-  end
-
-  # This is reachable via calling just /docs, currently we have no behavior associated, hence the message.
-  def show
-    render_result('Current API has no definition for just calling /docs.  Call /docs/changes or /docs/deletes')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   get 'about/version' => 'about#version'
   mount AboutPage::Engine => '/about(.:format)' # Or whever you want to access the about page
 
-  resource :docs, :defaults => { :format => 'json' } do
-    match 'deletes', :on => :collection, :via => [:get, :post]
-    match 'changes', :on => :collection, :via => [:get, :post]
+  resource :docs, :defaults => { :format => 'json' }, :only => [:get] do
+    get 'deletes'
+    get 'changes'
   end
 end

--- a/spec/features/docs_spec.rb
+++ b/spec/features/docs_spec.rb
@@ -69,30 +69,6 @@ describe('Docs Controller') do
     end
   end
 
-  describe('Tests Show Functions') do
-    let(:docs_response_with_time) do
-      VCR.use_cassette('show_call') do
-        visit "docs?last_modified=9999-01-01T00:00:00Z"
-        page.body
-      end
-    end
-    let(:docs_response_without_time) do
-      VCR.use_cassette('show_call') do
-        visit 'docs'
-        page.body
-      end
-    end
-
-    it 'returns responses that are not JSON' do
-      expect{ JSON.parse(docs_response_with_time) }.to raise_error(JSON::ParserError)
-      expect{ JSON.parse(docs_response_without_time) }.to raise_error(JSON::ParserError)
-    end
-
-    it 'return response that are the same regardless of time params' do
-      expect(docs_response_with_time).to match(docs_response_without_time)
-    end
-  end
-
   describe('Changes Response Respects Time Keys') do
   end
 end


### PR DESCRIPTION
This PR fixes #25. It changes the `/docs` routes to be `GET` only, and deletes the `show` and `index` (no-op) code in the controller.

AFTER:

```
     deletes_docs GET    /docs/deletes(.:format)         docs#deletes {:format=>"json"}
     changes_docs GET    /docs/changes(.:format)         docs#changes {:format=>"json"}
```

BEFORE:

```
     deletes_docs GET|POST /docs/deletes(.:format)         docs#deletes {:format=>"json"}
     changes_docs GET|POST /docs/changes(.:format)         docs#changes {:format=>"json"}
             docs POST     /docs(.:format)                 docs#create {:format=>"json"}
         new_docs GET      /docs/new(.:format)             docs#new {:format=>"json"}
        edit_docs GET      /docs/edit(.:format)            docs#edit {:format=>"json"}
                  GET      /docs(.:format)                 docs#show {:format=>"json"}
                  PATCH    /docs(.:format)                 docs#update {:format=>"json"}
                  PUT      /docs(.:format)                 docs#update {:format=>"json"}
                  DELETE   /docs(.:format)                 docs#destroy {:format=>"json"}
```