### PR TITLE
use configuration for PURL filesystem path

### DIFF
--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 require 'is_it_working'
 Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
   # Check that the PURL NFS mount directory
-  h.check :directory, :path => '/purl', :permission => [:read]
+  h.check :directory, :path => PurlFetcher::Application.config.solr_indexing['purl_document_path'], :permission => [:read]
 
   # Check that Solr is Working
   # h.check :rsolr, client: IndexerController.new.establish_solr_connection


### PR DESCRIPTION
This PR fixes `/is_it_working` so that it uses the configured PURL filesystem path -- for example:

```
Host: acomp-dhardy-01-mbpx.stanford.edu
PID:  39457
Timestamp: 2016-07-19T14:06:47-07:00
Elapsed Time: 24ms

FAIL : directory - /purl/document_cache does not exist (0ms)
OK   : solr_okay - solr core responds to select (23ms)
```