### PR TITLE
Refactor time to remove dependency on ApplicationController

### DIFF
--- a/lib/fetcher.rb
+++ b/lib/fetcher.rb
@@ -82,20 +82,6 @@ module Fetcher
     matches.nil? ? raise('invalid druid') : matches[0]
   end
 
-  # Given a hash containing "first_modified" and "last_modified", ensures the date formats are valid, converts to proper ISO8601 if they are.
-  # If first_modified is missing, sets to the earliest possible date.
-  # If last_modified is missing, sets to current date/time.
-  # If invalid dates are passed in, throws an exception.
-  # @param p [Hash] which includes :first_modified and :last_modified keys as coming in from the querystring from the user
-  # @return [Hash] containing :first and :last keys with proper vaues
-  # @example
-  #   get_times(:first_modified=>'01/01/2014') # returns {:first=>'2014-01-01T00:00:00Z',last:'CURRENT_DATETIME_IN_UTC_ISO8601'}
-  #   get_times(:first_modified=>'junk') # throws exception
-  #   get_times(:first_modified=>'01/01/2014',:last_modified=>'01/01/2015') # returns {:first=>'2014-01-01T00:00:00Z',last:'2015-01-01T00:00:00Z'}
-  def get_times(p = {})
-    ModificationTime.get_times(p)
-  end
-
   # Given a hash containing "first_modified" and "last_modified", returns the solr query part to append to the overall query to properly return dates,
   # which my be blank if user asks for just registered objects
   # @param p [hash] which includes :first_modified and :last_modified keys as coming in from the querystring from the user
@@ -104,7 +90,7 @@ module Fetcher
   #   get_date_solr_query(:first_modified=>'01/01/2014') # returns "and published_dt:["2014-01-01T00:00:00Z" TO "CURRENT_DATETIME"]"
   #   get_date_solr_query(:first_modified=>'01/01/2014',:status=>'registered') # returns ""
   def get_date_solr_query(p = {})
-    times = get_times(p)
+    times = ModificationTime.get_times(p)
     registered_only?(p) ? '' : "AND #{Last_Changed_Field}:[\"#{times[:first]}\" TO \"#{times[:last]}\"]" # unless the user has asked for only registered items, apply the date range for published date
   end
 
@@ -129,7 +115,7 @@ module Fetcher
   # @return [Hash] formatted json
   def format_json(params, response)
     all_json = {}
-    times = get_times(params)
+    times = ModificationTime.get_times(params)
 
     # Create A Hash that contains an empty list for each Fedora Type
     Fedora_Types.each do |_key, value|

--- a/lib/fetcher.rb
+++ b/lib/fetcher.rb
@@ -3,8 +3,6 @@ require 'active_support/inflector'
 # A mixin module that is part of application controller, this provides base functionality to all classes
 module Fetcher
 
-  Y_TEN_K = '9999-12-31T23:59:59Z'.freeze
-
   # Run a solr query, and do some logging
   # @param params [Hash] params to send to solr
   # @param method [String] type of query to send to solr (defaults to "select")

--- a/lib/fetcher.rb
+++ b/lib/fetcher.rb
@@ -93,17 +93,7 @@ module Fetcher
   #   get_times(:first_modified=>'junk') # throws exception
   #   get_times(:first_modified=>'01/01/2014',:last_modified=>'01/01/2015') # returns {:first=>'2014-01-01T00:00:00Z',last:'2015-01-01T00:00:00Z'}
   def get_times(p = {})
-    params = p || {}
-    first_modified = params[:first_modified] || Time.zone.at(0).iso8601
-    last_modified = params[:last_modified] || Y_TEN_K
-    begin
-      first_modified_time = Time.zone.parse(first_modified).iso8601
-      last_modified_time = Time.zone.parse(last_modified).iso8601
-    rescue
-      raise 'invalid time paramaters'
-    end
-    raise 'start time is before end time' if first_modified_time >= last_modified_time
-    { first: first_modified_time, last: last_modified_time }
+    ModificationTime.get_times(p)
   end
 
   # Given a hash containing "first_modified" and "last_modified", returns the solr query part to append to the overall query to properly return dates,

--- a/lib/modification_time.rb
+++ b/lib/modification_time.rb
@@ -8,15 +8,16 @@ class ModificationTime
   # @param [String] first_modified
   # @param [String] last_modified
   def initialize(first_modified: Time.zone.at(0).iso8601, last_modified: Y_TEN_K)
-    @first_modified = first_modified
-    @last_modified = last_modified
+    @first_modified = Time.zone.parse(first_modified)
+    @last_modified = Time.zone.parse(last_modified)
+    raise 'invalid time paramaters' if @first_modified.nil? || @last_modified.nil?
+    raise 'start time is before end time' if @first_modified >= @last_modified
   end
 
   ##
   # @return [Hash]
-  def convert
-    validate
-    { first: first_modified_time, last: last_modified_time }
+  def convert_to_iso8601
+    { first: first_modified.iso8601, last: last_modified.iso8601 }
   end
 
   ##
@@ -26,18 +27,6 @@ class ModificationTime
     arguments = {}
     arguments[:first_modified] = params[:first_modified] if params.present? && params[:first_modified].present?
     arguments[:last_modified] = params[:last_modified] if params.present? && params[:last_modified].present?
-    new(arguments).convert
-  end
-
-  private
-
-  def validate
-    begin
-      @first_modified_time = Time.zone.parse(first_modified).iso8601
-      @last_modified_time = Time.zone.parse(last_modified).iso8601
-    rescue
-      raise 'invalid time paramaters'
-    end
-    raise 'start time is before end time' if first_modified_time >= last_modified_time
+    new(arguments).convert_to_iso8601
   end
 end

--- a/lib/modification_time.rb
+++ b/lib/modification_time.rb
@@ -1,0 +1,43 @@
+##
+# Deals with setting a default first_modified_time and last_modified_time
+class ModificationTime
+  attr_reader :first_modified, :last_modified, :first_modified_time, :last_modified_time
+  Y_TEN_K = '9999-12-31T23:59:59Z'.freeze
+
+  ##
+  # @param [String] first_modified
+  # @param [String] last_modified
+  def initialize(first_modified: Time.zone.at(0).iso8601, last_modified: Y_TEN_K)
+    @first_modified = first_modified
+    @last_modified = last_modified
+  end
+
+  ##
+  # @return [Hash]
+  def convert
+    validate
+    { first: first_modified_time, last: last_modified_time }
+  end
+
+  ##
+  # A class method constructor used to conform to original API.
+  # @return [Hash]
+  def self.get_times(params = {})
+    arguments = {}
+    arguments[:first_modified] = params[:first_modified] if params.present? && params[:first_modified].present?
+    arguments[:last_modified] = params[:last_modified] if params.present? && params[:last_modified].present?
+    new(arguments).convert
+  end
+
+  private
+
+  def validate
+    begin
+      @first_modified_time = Time.zone.parse(first_modified).iso8601
+      @last_modified_time = Time.zone.parse(last_modified).iso8601
+    rescue
+      raise 'invalid time paramaters'
+    end
+    raise 'start time is before end time' if first_modified_time >= last_modified_time
+  end
+end

--- a/lib/modification_time.rb
+++ b/lib/modification_time.rb
@@ -10,8 +10,8 @@ class ModificationTime
   def initialize(first_modified: Time.zone.at(0).iso8601, last_modified: Y_TEN_K)
     @first_modified = Time.zone.parse(first_modified)
     @last_modified = Time.zone.parse(last_modified)
-    raise 'invalid time paramaters' if @first_modified.nil? || @last_modified.nil?
-    raise 'start time is before end time' if @first_modified >= @last_modified
+    raise ArgumentError, 'invalid time parameters' if @first_modified.nil? || @last_modified.nil?
+    raise ArgumentError, 'start time is before end time' if @first_modified >= @last_modified
   end
 
   ##

--- a/spec/features/fetcher_spec.rb
+++ b/spec/features/fetcher_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe('Fetcher lib') do
   let(:fetcher) { FetcherTester.new }
   let(:earliest) { '1970-01-01T00:00:00Z' }
-  let(:latest) { Fetcher::Y_TEN_K }
+  let(:latest) { ModificationTime::Y_TEN_K }
 
   it 'lets us know if the user only wants registered items' do
     expect(fetcher.registered_only?(nil)).to be false
@@ -53,7 +53,7 @@ describe('Fetcher lib') do
   end
 
   it 'raises an error when selected for an invalid date range' do
-    times = { first: Fetcher::Y_TEN_K, last: Fetcher::Y_TEN_K }
+    times = { first: ModificationTime::Y_TEN_K, last: ModificationTime::Y_TEN_K }
     last_changed = ['2014-05-05T05:04:13Z', '2014-04-05T05:04:13Z']
     expect{ fetcher.determine_latest_date(times, last_changed) }.to raise_error(RuntimeError)
   end

--- a/spec/features/fetcher_spec.rb
+++ b/spec/features/fetcher_spec.rb
@@ -22,40 +22,6 @@ describe('Fetcher lib') do
     expect(fetcher.get_date_solr_query(status: 'registered')).to eq('')
   end
 
-  it 'returns the current date and time when time not passed in' do
-    expect(fetcher.get_times(nil)).to eq(first: earliest, last: latest)
-    expect(fetcher.get_times({})).to eq(first: earliest, last: latest)
-    expect(fetcher.get_times(first_modified: nil, last_modified: '01/01/2014')).to eq(first: earliest, last: '2014-01-01T00:00:00Z')
-    expect(fetcher.get_times(first_modified: '01/01/2014', last_modified: nil)).to eq(first: '2014-01-01T00:00:00Z', last: latest)
-  end
-
-  it 'raises an exception if the start date is not before the end date' do
-    expect{ fetcher.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2009 10:00:00am') }.to raise_error('start time is before end time')
-    expect{ fetcher.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:00am') }.to raise_error('start time is before end time')
-    expect{ fetcher.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:01am') }.not_to raise_error
-  end
-
-  it 'raises an exception for either starting of ending date in an invalid format' do
-    expect{ fetcher.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: 'ness') }.to raise_error('invalid time paramaters')
-    expect{ fetcher.get_times(first_modified: 'bogus', last_modified: '01/01/2010 10:00:00am') }.to raise_error('invalid time paramaters')
-    expect{ fetcher.get_times(first_modified: 'bogus', last_modified: 'ness') }.to raise_error('invalid time paramaters')
-  end
-
-  it 'returns the properly formatted hash for various valid types of input date or time' do
-    expected = { first: '2010-01-01T10:00:00Z', last: '2011-01-01T10:00:00Z' }
-    inputs = [
-      { first_modified: '01/01/2010 10:00:00am',   last_modified: '01/01/2011 10:00:00am UTC' },
-      { first_modified: '2010-01-01T02:00:00 PST', last_modified: '01/01/2011 2:00:00am PST' },
-      { first_modified: '01/01/2010 10:00:00am',   last_modified: '2011-01-01T10:00:00Z' }
-    ]
-    inputs.each do |input|
-      expect(fetcher.get_times(input)).to eq(expected)
-    end
-    expect(fetcher.get_times(first_modified: '01/01/2010', last_modified: '2011-01-01T18:00:00Z')).to eq(first: '2010-01-01T00:00:00Z', last: '2011-01-01T18:00:00Z')
-    expect(fetcher.get_times(first_modified: '2011-01-01T18:00:00Z', last_modified: '2014-12-01')).to eq(first: '2011-01-01T18:00:00Z', last: '2014-12-01T00:00:00Z')
-    expect(fetcher.get_times(first_modified: 'January 1, 2009', last_modified: '2012-01-01T18:00:00Z')).to eq(first: '2009-01-01T00:00:00Z', last: '2012-01-01T18:00:00Z')
-  end
-
   it 'parses druids correctly' do
     expect(fetcher.parse_druid('druid:oo000oo0001')).to eq('oo000oo0001')
     expect(fetcher.parse_druid('oo000oo0001')).to eq('oo000oo0001')

--- a/spec/lib/modification_time_spec.rb
+++ b/spec/lib/modification_time_spec.rb
@@ -12,15 +12,15 @@ describe ModificationTime do
     end
 
     it 'raises an exception if the start date is not before the end date' do
-      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2009 10:00:00am') }.to raise_error('start time is before end time')
-      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:00am') }.to raise_error('start time is before end time')
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2009 10:00:00am') }.to raise_error(ArgumentError, 'start time is before end time')
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:00am') }.to raise_error(ArgumentError, 'start time is before end time')
       expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:01am') }.not_to raise_error
     end
 
     it 'raises an exception for either starting of ending date in an invalid format' do
-      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: 'ness') }.to raise_error('invalid time paramaters')
-      expect{ described_class.get_times(first_modified: 'bogus', last_modified: '01/01/2010 10:00:00am') }.to raise_error('invalid time paramaters')
-      expect{ described_class.get_times(first_modified: 'bogus', last_modified: 'ness') }.to raise_error('invalid time paramaters')
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: 'ness') }.to raise_error(ArgumentError, 'invalid time parameters')
+      expect{ described_class.get_times(first_modified: 'bogus', last_modified: '01/01/2010 10:00:00am') }.to raise_error(ArgumentError, 'invalid time parameters')
+      expect{ described_class.get_times(first_modified: 'bogus', last_modified: 'ness') }.to raise_error(ArgumentError, 'invalid time parameters')
     end
 
     it 'returns the properly formatted hash for various valid types of input date or time' do
@@ -46,16 +46,16 @@ describe ModificationTime do
     it 'validates inputs' do
       expect do
         described_class.new(first_modified: 'not a time')
-      end.to raise_error 'invalid time paramaters'
+      end.to raise_error ArgumentError, 'invalid time parameters'
       expect do
         described_class.new(last_modified: 'not a time')
-      end.to raise_error 'invalid time paramaters'
+      end.to raise_error ArgumentError, 'invalid time parameters'
       expect do
         described_class.new(
           last_modified: Time.zone.at(0).iso8601,
           first_modified: described_class::Y_TEN_K
         )
-      end.to raise_error 'start time is before end time'
+      end.to raise_error ArgumentError, 'start time is before end time'
     end
   end
   describe '#convert_to_iso8601' do

--- a/spec/lib/modification_time_spec.rb
+++ b/spec/lib/modification_time_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe ModificationTime do
+  describe '.get_times' do
+    let(:earliest) { '1970-01-01T00:00:00Z' }
+    let(:latest) { Fetcher::Y_TEN_K }
+    it 'returns the current date and time when time not passed in' do
+      expect(described_class.get_times(nil)).to eq(first: earliest, last: latest)
+      expect(described_class.get_times({})).to eq(first: earliest, last: latest)
+      expect(described_class.get_times(first_modified: nil, last_modified: '01/01/2014')).to eq(first: earliest, last: '2014-01-01T00:00:00Z')
+      expect(described_class.get_times(first_modified: '01/01/2014', last_modified: nil)).to eq(first: '2014-01-01T00:00:00Z', last: latest)
+    end
+
+    it 'raises an exception if the start date is not before the end date' do
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2009 10:00:00am') }.to raise_error('start time is before end time')
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:00am') }.to raise_error('start time is before end time')
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: '01/01/2010 10:00:01am') }.not_to raise_error
+    end
+
+    it 'raises an exception for either starting of ending date in an invalid format' do
+      expect{ described_class.get_times(first_modified: '01/01/2010 10:00:00am', last_modified: 'ness') }.to raise_error('invalid time paramaters')
+      expect{ described_class.get_times(first_modified: 'bogus', last_modified: '01/01/2010 10:00:00am') }.to raise_error('invalid time paramaters')
+      expect{ described_class.get_times(first_modified: 'bogus', last_modified: 'ness') }.to raise_error('invalid time paramaters')
+    end
+
+    it 'returns the properly formatted hash for various valid types of input date or time' do
+      expected = { first: '2010-01-01T10:00:00Z', last: '2011-01-01T10:00:00Z' }
+      inputs = [
+        { first_modified: '01/01/2010 10:00:00am',   last_modified: '01/01/2011 10:00:00am UTC' },
+        { first_modified: '2010-01-01T02:00:00 PST', last_modified: '01/01/2011 2:00:00am PST' },
+        { first_modified: '01/01/2010 10:00:00am',   last_modified: '2011-01-01T10:00:00Z' }
+      ]
+      inputs.each do |input|
+        expect(described_class.get_times(input)).to eq(expected)
+      end
+      expect(described_class.get_times(first_modified: '01/01/2010', last_modified: '2011-01-01T18:00:00Z')).to eq(first: '2010-01-01T00:00:00Z', last: '2011-01-01T18:00:00Z')
+      expect(described_class.get_times(first_modified: '2011-01-01T18:00:00Z', last_modified: '2014-12-01')).to eq(first: '2011-01-01T18:00:00Z', last: '2014-12-01T00:00:00Z')
+      expect(described_class.get_times(first_modified: 'January 1, 2009', last_modified: '2012-01-01T18:00:00Z')).to eq(first: '2009-01-01T00:00:00Z', last: '2012-01-01T18:00:00Z')
+    end
+  end
+end


### PR DESCRIPTION
This pull request refactors our modules so that we don't have a class variable referencing `ApplicationController`. It looks like we did that just so we could share code between modules?? 😢 

Popped the logic in a plain old ruby object and ported over existing specs. I would be amenable to adding more unit tests.