### PR TITLE
removes all the duplicated code in the indexing rake tasks

### DIFF
--- a/lib/tasks/indexing.rake
+++ b/lib/tasks/indexing.rake
@@ -1,40 +1,39 @@
+require 'fileutils'
 require 'logger'
+
+desc 'Index objects modified in last n minutes. Defaults to 1 hour'
+task :index_changes, [:mins_ago, :logfile] => :environment do |_t, args|
+  args.with_defaults(mins_ago: 60, logfile: 'log/indexing_rake_task.log')
+  start_time = Time.zone.now
+  result = IndexerController.new.index_all_modified_objects(mins_ago: args[:mins_ago] + 1) # adding one minute for slop
+
+  # ensure log folder is created
+  path = File.dirname(args[:logfile])
+  FileUtils.mkdir_p path unless File.directory?(path)
+
+  # log result
+  indexing_log = Logger.new(args[:logfile])
+  indexing_log.info("Running of rake task 'index_changes' for #{args[:mins_ago]} mins ago at #{start_time} returned a result of #{result}")
+end
 
 desc 'Search for all objects modified within the last 5 minutes and add index them into to solr'
 task :index_changes_in_last_five_minutes => :environment do
-  start_time = Time.zone.now
-  indexer = IndexerController.new
-  result = indexer.index_all_modified_objects(mins_ago: 6) # adding one minute for slop
-  indexing_log = Logger.new('log/indexing_rake_task.log')
-  indexing_log.info("Running of rake task index_changes_in_last_five_minutes at #{start_time} returned a result of #{result}")
+  Rake::Task[:index_changes].invoke(5)
 end
 
 desc 'Search for all objects modified within the last 15 minutes and add index them into to solr'
 task :index_changes_in_last_fifteen_minutes => :environment do
-  start_time = Time.zone.now
-  indexer = IndexerController.new
-  result = indexer.index_all_modified_objects(mins_ago: 16) # adding one minute for slop
-  indexing_log = Logger.new('log/indexing_rake_task.log')
-  indexing_log.info("Running of rake task index_changes_in_last_fifteen_minutes at #{start_time} returned a result of #{result}")
+  Rake::Task[:index_changes].invoke(15)
 end
 
 desc 'Search for all objects modified within the last 2 hours and add index them into to solr'
 task :index_changes_in_last_two_hours => :environment do
-  start_time = Time.zone.now
-  indexer = IndexerController.new
-  result = indexer.index_all_modified_objects(mins_ago: 121) # adding one minute for slop
-  indexing_log = Logger.new('log/indexing_rake_task.log')
-  indexing_log.info("Running of rake task index_changes_in_last_two_hours at #{start_time} returned a result of #{result}")
+  Rake::Task[:index_changes].invoke(2*60)
 end
 
 desc 'Search for all objects modified since the start of the Unix Epoch and add index them into to solr'
 task :index_since_beginning_of_unix_time => :environment do
-  start_time = Time.zone.now
-  minutes_since_epoch = (Time.zone.now.to_i / 60.0).ceil
-  indexer = IndexerController.new
-  result = indexer.index_all_modified_objects(mins_ago: minutes_since_epoch + 1) # adding one minute for slop
-  indexing_log = Logger.new('log/indexing_rake_task.log')
-  indexing_log.info("Running of rake task index_since_beginning_of_unix_time at #{start_time} returned a result of #{result}")
+  Rake::Task[:index_changes].invoke((Time.zone.now.to_i / 60.0).ceil)
 end
 
 desc 'Search for all objects deleted within the last 5 minutes and update solr'


### PR DESCRIPTION
This PR fixes #26. It removes all the duplicated code in the indexing rake tasks by creating a new task `index_changes` that is parameterized. The PR is backward compatible with all the indexing rake tasks (e.g., `index_changes_in_last_five_minutes`, etc.). The PR also ensures that the directory of the logfile exists.

The complete list of indexing rake tasks is as follows:

```
rake index_changes[mins_ago,logfile]             # Index objects modified in last n minutes
rake index_changes_in_last_fifteen_minutes       # Search for all objects modified within the last 15 minutes and add index the...
rake index_changes_in_last_five_minutes          # Search for all objects modified within the last 5 minutes and add index them...
rake index_changes_in_last_two_hours             # Search for all objects modified within the last 2 hours and add index them i...
rake index_since_beginning_of_unix_time          # Search for all objects modified since the start of the Unix Epoch and add in...
```