### PR TITLE
add logging for each item processed and sent to solr during indexing

### DIFF
--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -258,8 +258,13 @@ module Indexer
     solr = establish_solr_connection
     response = {}
     begin
+      docs = add_timestamp_to_documents(documents)
+      docs.map do |d|
+        @@log.info("Processing item #{d[:id]} (#{d[@@indexer_config['deleted_field'].to_sym] == 'true' ? 'deleting' : 'adding'})")
+      end
       with_retries(max_retries: 5, base_sleep_seconds: 3, max_sleep_seconds: 15, rescue: RSolr::Error) do
-        response = solr.add add_timestamp_to_documents(documents)
+        @@log.info("Sending #{docs.size} records to Solr")
+        response = solr.add docs
       end
       success = parse_solr_response(response)
     rescue StandardError => e

--- a/spec/features/indexer_spec.rb
+++ b/spec/features/indexer_spec.rb
@@ -166,6 +166,8 @@ describe('Indexer lib') do
   it 'determines when the addition and commit of solr documents was successful' do
     VCR.use_cassette('submit_one_doc') do
       docs = [indexer.solrize_object(sample_doc_path)]
+      expect(indexer.log_object).to receive(:info).with(/Processing item.*adding/).once
+      expect(indexer.log_object).to receive(:info).with(/Sending 1 record/).once
       expect(indexer.add_and_commit_to_solr(docs)).to be_truthy
     end
   end
@@ -270,6 +272,8 @@ describe('Indexer lib') do
         FileUtils.rm_r dest_dir # remove its files
         druid_object.creates_delete_record # create its delete record
 
+        expect(indexer.log_object).to receive(:info).with(/Processing item.*deleting/).once
+        expect(indexer.log_object).to receive(:info).with(/Sending/).once
         result = indexer.remove_deleted_objects_from_solr(mins_ago: 5)
         sleep(1) # make sure at least one second passes for the timestamp checks
         end_time = Time.zone.now


### PR DESCRIPTION
This PR is connected to #46. It adds a minimal set of logging for indexing items (adds and deletes).