### PR TITLE
skip "sleep(61)" test until we can rewrite the test correctly

### DIFF
--- a/spec/features/indexer_spec.rb
+++ b/spec/features/indexer_spec.rb
@@ -342,6 +342,7 @@ describe('Indexer lib') do
     # get_all_changed_objects_for_branch
     #
     it 'detects when a purl has been changed' do
+      skip 'there is a race condition or something that causes this test to fail sporadically'
       FileUtils.rm_r dest_dir if File.directory?(dest_dir) # If this test failed and isreun, clear the directory
       branch = purl_fixture_path + File::SEPARATOR + 'bb'
       indexer.instance_variable_set(:@modified_at_or_later, 1) # Set the default mod time to one minute


### PR DESCRIPTION
This PR is connected to #52. It simply disables the broken test until we can rewrite it.