### PR TITLE
standardizes logfile and adds index_deletes target

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ rake jetty:start
 rails server
 ```
 
+## Logging
+
+There are three log files:
+
+* `indexing.log` - items that are being indexed (added or deleted)
+* `[environment].log` - debug information for Solr queries
+* `access.log` and `error.log` from Apache - traffic to the HTTP APIs
+
 ## Running tests
 
 ### To run the tests against the current VCR Cassettes:


### PR DESCRIPTION
This PR fixes #46. It simply standardizes the logfile name to `log/indexing.log` for the indexing rake tasks. It also creates an `index_deletes` target to reduce future code duplication.