### PR TITLE
send cron output to /dev/null

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,8 @@
 
 # Learn more: http://github.com/javan/whenever
 
+set :output, "/dev/null"
+
 every 120.minutes do
    rake 'index_since_last_run'
  end


### PR DESCRIPTION
@eefahy not sure if you want to log the cron output, but this PR sends it to /dev/null.