### PR TITLE
Add default Rails 4.2.6 database.yml and remove configuration task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@
 
 /public/*.gz
 /public/sitemap.xml
-config/database.yml
 
 nohup.out
 REVISION

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ git clone https://github.com/sul-dlss/purl-fetcher.git
 cd purl-fetcher
 
 bundle install
-rake purlfetcher:config
-
-# Edit config/database.yml file
 
 rake db:migrate
 rake db:migrate RAILS_ENV=test

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,17 +3,23 @@
 #
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
-development:
+#
+default: &default
   adapter: sqlite3
-  database: db/development.sqlite3
   pool: 5
   timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
+  <<: *default
   database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
+
+production:
+  <<: *default
+  database: db/production.sqlite3

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -10,7 +10,6 @@ end
 
 desc 'Run continuous integration suite without rubocop for travis'
 task :travis_ci do
-  Rake::Task['purlfetcher:config'].invoke
   system('RAILS_ENV=test rake db:migrate')
   system('RAILS_ENV=test rake db:test:prepare')
   Rake::Task['rspec'].invoke
@@ -25,12 +24,5 @@ task :rubocop do
     rescue LoadError
       puts 'Unable to load RuboCop.'
     end
-  end
-end
-
-namespace :purlfetcher do
-  desc 'Copy all configuration files'
-  task :config do
-    cp("#{Rails.root}/config/database.yml.example", "#{Rails.root}/config/database.yml", :verbose => true)
   end
 end


### PR DESCRIPTION
We already have this as a linked file on deploy and our systems
handle this file automatically. No reason to ignore it anymore.