### PR TITLE
implements simple /collections API

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,54 @@
+class CollectionsController < ApplicationController
+  ##
+  # API call to get a full list of all PURL collections
+  #
+  # @param [querystring] Parameters can be specified in the querystring
+  #   * rows = number of results to return (set to 0 to only get count)
+  #
+  #  http://localhost:3000/collections
+  #  http://localhost:3000/collections?rows=0
+  #
+  # @return [Array<String>] list of druids for all PURL collections
+  #
+  #
+  #
+  def index
+    collections = Purl.where(object_type: %w(set collection))
+    if params[:rows] == '0'
+      respond_to do |format|
+        format.json { render json: { size: collections.size}.to_json }
+      end
+    else
+      respond_to do |format|
+        format.json { render json: collections.to_a.map(&:druid).to_json }
+      end
+    end
+  end
+
+  ##
+  # API call to get a list of PURL druids associated with a specific collection
+  #
+  # @param [querystring] Parameters can be specified in the querystring
+  #   * rows = number of results to return (set to 0 to only get count)
+  #
+  #  http://localhost:3000/collections/druid:aa111bb2222
+  #  http://localhost:3000/collections/druid:aa111bb2222?rows=0
+  #
+  # @return [Array<String>] list of druids for all PURLs that are members of the given collection
+  #
+  def show
+    druid = params.require(:id)
+    fail ArgumentError, "Invalid collection: #{druid}" unless Collection.find_by_druid(druid).present?
+
+    purls = Purl.joins(:collections).where('collections.druid = ?', druid)
+    if params[:rows] == '0'
+      respond_to do |format|
+        format.json { render json: { size: purls.size}.to_json }
+      end
+    else
+      respond_to do |format|
+        format.json { render json: purls.to_a.map(&:druid).to_json }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,8 @@ Rails.application.routes.draw do
     get 'deletes'
     get 'changes'
   end
+
+  get 'collections' => 'collections#index', defaults: { :format => 'json' }
+  get 'collections/:id' => 'collections#show', defaults: { :format => 'json' },
+    constraints: { id: /druid:[a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4}/ }
 end

--- a/spec/features/collections_controller_spec.rb
+++ b/spec/features/collections_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe(CollectionsController, type: :request, integration: true) do
+  it "fetches all collections" do
+    get '/collections'
+    expect(response).to be_success
+    results = JSON.parse(response.body)
+    expect(results).to be_an(Array)
+    expect(results).to eq ['druid:ee1111ff2222']
+  end
+
+  it "counts the number of collections" do
+    get '/collections?rows=0'
+    expect(response).to be_success
+    results = JSON.parse(response.body)
+    expect(results).to be_an(Hash)
+    expect(results).to eq({ 'size' => 1 })
+  end
+
+  it 'fetches all items that are members of a collection' do
+    get '/collections/druid:oo000oo0001'
+    expect(response).to be_success
+    results = JSON.parse(response.body)
+    expect(results).to be_an(Array)
+    expect(results).to eq ['druid:bb1111cc2222', 'druid:dd1111ee2222']
+  end
+
+  it "counts the items that are members of a collection" do
+    get '/collections/druid:oo000oo0001?rows=0'
+    expect(response).to be_success
+    results = JSON.parse(response.body)
+    expect(results).to be_an(Hash)
+    expect(results).to eq({ 'size' => 2 })
+  end
+
+end


### PR DESCRIPTION
This PR fixes #2 and implements a bare bones API for `/collections`. Namely:

* `GET /collections` returns a JSON array of all PURL collections druids
* `GET /collections?rows=0` returns count of all PURL collections
* `GET /collections/druid:aa111bb2222` returns JSON array of all PURL druids in the collection
* `GET /collections/druid:aa111bb2222?rows=0` returns count of all PURLs in the collection

As of 8/8, the design of the full API is still TBD. As such, I resurrected only the most basic level of functionality from PR #68. The current design document lives here: https://consul.stanford.edu/display/GRYPHONDOR/PURL+Fetcher