### PR TITLE
add index_from_file task to index a set of given PURLs

### DIFF
--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -3,9 +3,11 @@ class Purl < ActiveRecord::Base
   has_and_belongs_to_many :collections
   has_many :release_tags, dependent: :destroy
 
-  # class level method to create or update a purl model object given a path to a purl public xml file
+  # class level method to create or update a purl model object given a path to a purl directory
+  # @param [String] `path` path to a PURL directory
+  # @return [Boolean] success or failure
   def self.index(path)
-    public_xml = PurlParser.new(path)
+    public_xml = PurlParser.new(path) # NOTE: PurlParser appends 'public' to pathname
 
     if public_xml.exists?
       purl = self.find_or_create_by(druid: public_xml.druid) # either create a new druid record or get the existing one

--- a/lib/tasks/indexing.rake
+++ b/lib/tasks/indexing.rake
@@ -1,3 +1,4 @@
+require 'benchmark'
 require 'fileutils'
 require 'logger'
 require 'purl_finder'
@@ -27,4 +28,27 @@ end
 desc 'Search for all objects deleted within the last 5 minutes and update database'
 task :process_all_deletes_in_last_five_minutes => :environment do
   Rake::Task[:index_deletes].invoke(5)
+end
+
+desc 'Index a specific set of PURLs given a file pointing to the public XML files'
+task :index_from_file, [:filename] => :environment do |_t, args|
+  unless args.filename.present? && File.size?(args.filename)
+    fail ArgumentError, "Requires a filename that contains the public XML file paths"
+  end
+  n = 0
+  elapsed_time = Benchmark.realtime do
+    IO.foreach(args.filename) do |line|
+      path = line.strip
+      # Purl.index takes _directory_ paths, not public XML filenames
+      path = File.dirname(path) if File.file?(path)
+      if File.file?(File.join(path, 'public'))
+        Purl.index(path)
+        IndexingLogger.info("Indexed #{path}")
+        n += 1
+      else
+        IndexingLogger.error("Missing public file in #{path}. Skipping indexing")
+      end
+    end
+  end
+  IndexingLogger.info("Indexed #{n} items from #{args.filename} in #{elapsed_time.ceil} seconds")
 end


### PR DESCRIPTION
This PR is connected to #66. 

It adds a simple `index_from_file[filename]` rake task that indexes all of the public XML files listed in the given `filename`. This PR gives the listener an option to use rake to do its indexing calls.

```
rake index_from_file[filename]                   # Index a specific set of PURLs given a file pointing to the public XML files
```