### PR TITLE
add missing dc file which is published

### DIFF
--- a/spec/purl-test-fixtures/document_cache/bb/050/dj/7711/dc
+++ b/spec/purl-test-fixtures/document_cache/bb/050/dj/7711/dc
@@ -1,0 +1,11 @@
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:type>StillImage</dc:type>
+    <dc:type>digital image</dc:type>
+    <dc:subject>Automobile--History</dc:subject>
+    <dc:date>1937</dc:date>
+    <dc:title>This is Pete's New Test title for this object.</dc:title>
+    <dc:identifier>2011-023DUG-3.0_0025</dc:identifier>
+    <dc:subject>There are some guys in the photo</dc:subject>
+    <dc:relation type="collection">Revs Institute</dc:relation>
+    <dc:relation type="collection">The John Dugdale Collection of the Revs Institute</dc:relation>
+  </oai_dc:dc>

--- a/spec/purl-test-fixtures/document_cache/ct/961/sj/2730/dc
+++ b/spec/purl-test-fixtures/document_cache/ct/961/sj/2730/dc
@@ -1,0 +1,26 @@
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+<dc:title>Caroline Batchelor Map Collection.</dc:title>
+<dc:contributor>Batchelor, Caroline (collector.)</dc:contributor>
+<dc:contributor>Arrowsmith, John.</dc:contributor>
+<dc:contributor>Bartholomew, John, 1805-1861</dc:contributor>
+<dc:contributor>Bonne, Rigobert, 1727-1794</dc:contributor>
+<dc:contributor>Migeon, J.</dc:contributor>
+<dc:contributor>Moll, Herman, -1732</dc:contributor>
+<dc:contributor>Petermann, A. (August), 1822-1878</dc:contributor>
+<dc:contributor>Wyld, James, 1812-1887</dc:contributor>
+<dc:contributor>Justus Perthes (Firm : Gotha, Germany)</dc:contributor>
+<dc:contributor>
+Society for the Diffusion of Useful Knowledge (Great Britain)
+</dc:contributor>
+<dc:language>eng</dc:language>
+<dc:format>294 maps, prints and books.</dc:format>
+<dc:description>
+This collection of primarily maps with a few prints and books portrays the continent of Africa as well as detailed maps of different regions and countries on the continent. The maps range in date from 1550 to approximately 1800. Individual maps cataloged separately and held at Branner Earth Sciences Library and Map Collections by call number.
+</dc:description>
+<dc:coverage>Africa</dc:coverage>
+<dc:coverage>Egypt</dc:coverage>
+<dc:coverage>Northern Africa</dc:coverage>
+<dc:coverage>South Africa</dc:coverage>
+<dc:coverage>Africa, Southern</dc:coverage>
+<dc:coverage>Africa, West</dc:coverage>
+</oai_dc:dc>


### PR DESCRIPTION
This PR adds the missing `dc` file to our `document_cache` fixtures -- they will be there on publish.