### PR TITLE
drop unused cached fields title and catkey

### DIFF
--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -17,9 +17,7 @@ class Purl < ActiveRecord::Base
 
       # set the purl model attributes
       purl.druid = public_xml.druid
-      purl.title = public_xml.title
       purl.object_type = public_xml.object_type
-      purl.catkey = public_xml.catkey
 
       # add the collections they exist
       public_xml.collections.each { |collection| purl.collections << Collection.where(druid: collection).first_or_create }

--- a/db/migrate/20160810165852_drop_unneeded_cached_fields.rb
+++ b/db/migrate/20160810165852_drop_unneeded_cached_fields.rb
@@ -1,0 +1,6 @@
+class DropUnneededCachedFields < ActiveRecord::Migration
+  def change
+    remove_column :purls, :title
+    remove_column :purls, :catkey
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160809220038) do
+ActiveRecord::Schema.define(version: 20160810165852) do
 
   create_table "collections", force: :cascade do |t|
     t.string   "druid",      null: false
@@ -31,9 +31,7 @@ ActiveRecord::Schema.define(version: 20160809220038) do
 
   create_table "purls", force: :cascade do |t|
     t.string   "druid",        null: false
-    t.string   "title"
     t.string   "object_type"
-    t.string   "catkey"
     t.datetime "deleted_at"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false

--- a/test/fixtures/purls.yml
+++ b/test/fixtures/purls.yml
@@ -7,38 +7,28 @@
 indexed_1:
   id: 1
   druid: druid:bb1111cc2222
-  title: Some test object
   object_type: item
-  catkey: ''
   published_at: <%=Time.zone.parse('1/1/2015').iso8601%>
 indexed_2:
   id: 2
   druid: druid:cc1111dd2222
-  title: Some test object number 2 that was later deleted
   object_type: item
-  catkey: '567'
   published_at: <%=Time.zone.parse('1/1/2016').iso8601%>
   deleted_at: <%=Time.zone.parse('2/1/2016').iso8601%>
 indexed_3:
   id: 3
   druid: druid:dd1111ee2222
-  title: Some test object number 3
   object_type: item
-  catkey: ''
   published_at: <%=Time.zone.parse('1/1/2014').iso8601%>
 indexed_4:
   id: 4
   druid: druid:ee1111ff2222
-  title: Some test object number 4
   object_type: set
-  catkey: ''
   published_at: <%=Time.zone.parse('1/1/2013').iso8601%>
   deleted_at: <%=Time.zone.parse('1/1/2014').iso8601%>
 indexed_5:
   id: 5
   druid: druid:ff1111gg2222
-  title: Some test object number 5
   object_type: collection
-  catkey: ''
   published_at: <%=Time.zone.parse('1/1/2013').iso8601%>
   deleted_at: <%=Time.zone.parse('1/1/2014').iso8601%>


### PR DESCRIPTION
@mejackreed This PR removes a couple unused `Purl` fields -- `title` and `catkey`