### PR TITLE
add PurlListener to watch for recent changes in published PURLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /log/*.log
 /log/*.txt
 /tmp
+/run/*.pid
 /db/*.sqlite3
 /db/*.sqlite3-journal
 

--- a/Capfile
+++ b/Capfile
@@ -27,6 +27,7 @@ require 'capistrano/rvm'
 require 'whenever/capistrano'
 require 'capistrano/honeybadger'
 require 'capistrano/rails/migrations'
+require 'capistrano/passenger'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'is_it_working-cbeer'
 gem 'about_page'
 gem 'honeybadger', '~> 2.0'
+gem 'listen'
 
 group :test do
   gem 'yard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
     eventmachine (1.2.0.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.14)
     git-version-bump (0.15.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -135,6 +136,10 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -201,8 +206,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.2.2)
-    rdoc (4.2.2)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
       json (~> 1.4)
+    rdoc (4.2.2)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -233,6 +241,7 @@ GEM
       unicode-display_width (~> 0.3)
     rubocop-rspec (1.4.0)
     ruby-progressbar (1.8.1)
+    ruby_dep (1.4.0)
     safe_yaml (1.0.4)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
@@ -302,6 +311,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   kaminari
   launchy
+  listen
   meta_request
   mysql2
   rails (~> 4.2)

--- a/app/models/listener_log.rb
+++ b/app/models/listener_log.rb
@@ -1,0 +1,27 @@
+# Log of purl-fetcher-listener processes that have run or are running
+class ListenerLog < ActiveRecord::Base
+  ##
+  # @return [ListenerLog] the most recent listener that was started
+  def self.current
+    order('started_at DESC').limit(1).first
+  end
+
+  ##
+  # @return <Integer|Nil> `nil` if the listener has never run,
+  # otherwise time since now that it was last started
+  def self.minutes_since_last_started
+    ((Time.now - current.started_at) / 60.0).ceil
+  rescue
+    nil
+  end
+
+  ##
+  # @return <Integer|Nil> `nil` if the listener has never done any work,
+  # otherwise time since now that it was last active
+  def self.minutes_since_last_active
+    last_log = order('active_at DESC, started_at DESC').limit(1).first
+    ((Time.now - last_log.active_at) / 60.0).ceil
+  rescue
+    nil
+  end
+end

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -2,14 +2,19 @@ defaults: &defaults
   filename_indexing_log: "log/indexing.log"
   purl_document_path: "/purl/document_cache"
   deletes_dir: ".deletes"
+  listener_path: "/purl/recent_changes"
+  listener_pid_file: "<%=File.join(Rails.root,'run','listener.pid')%>"
   base_filename_finder_log: "purl_finder"
   base_path_finder_log: "<%=File.join(Rails.root,'log')%>"
 
 development:
   <<: *defaults
   purl_document_path: "<%=Rails.root%>/spec/purl-test-fixtures/document_cache"
+  listener_path: "<%=Rails.root%>/spec/purl-test-fixtures/recent_changes"
 test:
   <<: *defaults
+  purl_document_path: "<%=Rails.root%>/spec/purl-test-fixtures/document_cache"
+  listener_path: "<%=Rails.root%>/spec/purl-test-fixtures/recent_changes"
 staging:
   <<: *defaults
 production:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 set :linked_files, %w{config/secrets.yml config/database.yml config/honeybadger.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{log run tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
 # Default value for keep_releases is 5
 set :keep_releases, 5
@@ -25,3 +25,17 @@ server "purl-fetcher-#{fetch(:stage)}.stanford.edu", user: fetch(:user), roles: 
 
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, "#{fetch(:stage)}"
+
+desc 'Restart the PurlListener'
+namespace :deploy do
+  task :restart do
+    on primary(:app) do
+      within current_path do
+        with :rails_env => fetch(:rails_env) do
+          execute :rake, 'listener:restart'
+        end
+      end
+    end
+  end
+end
+after 'deploy:published', 'deploy:restart'

--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -1,6 +1,14 @@
 require 'is_it_working'
 Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
-  # Check that the PURL NFS mount directory
+  # Check that the PURL NFS mount directory (listener needs write ability)
   h.check :directory, :path => PurlFetcher::Application.config.app_config['purl_document_path'], :permission => [:read]
+  h.check :directory, :path => PurlFetcher::Application.config.app_config['listener_path'], :permission => [:read, :write]
   h.check :active_record, :async => false
+  h.check :listener do |status|
+    if Process.kill(0, ListenerLog.current.process_id)
+      status.ok("listener is running")
+    else
+      status.fail("listener is not running")
+    end
+  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,10 +2,6 @@
 
 set :output, '/dev/null'
 
-every 1.day do
- rake 'find:all' # does full scan of everything both changes and delete
-end
-
 every 15.minutes do
  rake 'find:deletes[15]' # scan .deletes directory for new deletes
 end

--- a/db/migrate/20160811232523_create_listener_logs.rb
+++ b/db/migrate/20160811232523_create_listener_logs.rb
@@ -1,0 +1,13 @@
+class CreateListenerLogs < ActiveRecord::Migration
+  def change
+    create_table :listener_logs do |t|
+      t.integer :process_id, null: false    # UNIX pid for listener daemon
+      t.timestamp :started_at, null: false  # when the listener was started
+      t.timestamp :active_at                # last time the listener did anything
+      t.timestamp :ended_at                 # when the listener was stopped
+      t.timestamps null: false              # Rails-managed create/update times
+    end
+    add_index :listener_logs, :process_id
+    add_index :listener_logs, :started_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160811122848) do
+ActiveRecord::Schema.define(version: 20160811232523) do
 
   create_table "collections", force: :cascade do |t|
     t.string   "druid",      null: false
@@ -28,6 +28,18 @@ ActiveRecord::Schema.define(version: 20160811122848) do
 
   add_index "collections_purls", ["collection_id"], name: "index_collections_purls_on_collection_id"
   add_index "collections_purls", ["purl_id"], name: "index_collections_purls_on_purl_id"
+
+  create_table "listener_logs", force: :cascade do |t|
+    t.integer  "process_id", null: false
+    t.datetime "started_at", null: false
+    t.datetime "active_at"
+    t.datetime "ended_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "listener_logs", ["process_id"], name: "index_listener_logs_on_process_id"
+  add_index "listener_logs", ["started_at"], name: "index_listener_logs_on_started_at"
 
   create_table "purls", force: :cascade do |t|
     t.string   "druid",        null: false

--- a/lib/purl_finder.rb
+++ b/lib/purl_finder.rb
@@ -62,7 +62,7 @@ class PurlFinder
     mins_ago = params[:mins_ago] || nil
     output_file = params[:output_file] || default_output_file
     search_string = "find #{purl_mount_location} -name public -type f"
-    search_string += " -mmin -#{mins_ago}" if mins_ago
+    search_string += " -mmin -#{mins_ago.to_i}" if mins_ago
     search_string += "> #{output_file}" # store the results in a tmp file so we don't have to keep everything in memory
     IndexingLogger.info("Finding public files")
     IndexingLogger.info(search_string)
@@ -107,7 +107,7 @@ class PurlFinder
     # If we called the below statement with a /* on the end it would not return itself, however it would then throw errors on servers that don't yet have
     # a deleted object and thus don't have a .deletes dir
     search_string = "find #{path_to_deletes_dir}"
-    search_string += " -mmin -#{mins_ago}" if mins_ago
+    search_string += " -mmin -#{mins_ago.to_i}" if mins_ago
 
     deleted_objects = `#{search_string}`.split
     deleted_objects -= [path_to_deletes_dir] # remove the deleted objects dir itself

--- a/lib/purl_listener.rb
+++ b/lib/purl_listener.rb
@@ -1,0 +1,179 @@
+require 'benchmark'
+require 'fileutils'
+require 'listen'
+
+##
+# PurlListener supports incremental PURL updates via a "dropbox" folder
+# on the PURL filesystem. The implementation assumes that the PURL filesystem
+# is mounted via NFS and is a read-write mount.
+#
+# This is the basic algorithm:
+#
+# watches "dropbox" directory for filesystem events,
+# then on event:
+#     - logs that the listener process is active
+#     - rename `aa111bb2222` to `aa111bb2222.lock`
+#     - save to `Purl` model, and logs (to file and Honeybadger) any exceptions (then continues)
+#     - delete `aa111bb2222.lock`
+#
+# when listener boots:
+#     - it checks to see when it was last active
+#     - then runs a `find:all[mins_ago]` task
+#
+class PurlListener
+
+  attr_reader :event_handler, :logger, :path, :pid_file
+
+  ##
+  # @param [Pathname] `path` -- the single "dropbox" directory
+  # @param [Pathname] `pid_file` -- the location of the pid file
+  # @param [Logger] `logger` -- place to log info/warn/errors
+  # @raise [ArgumentError] -- requires path to be a directory
+  def initialize(path = Pathname(PurlFetcher::Application.config.app_config['listener_path']),
+                 pid_file = Pathname(PurlFetcher::Application.config.app_config['listener_pid_file']),
+                 logger = IndexingLogger)
+    raise ArgumentError, "Missing #{path}" unless path.directory?
+    @pid_file = pid_file
+    @pid = nil
+    @path = path
+    @logger = logger
+    @event_handler = proc do |modified, added, removed|
+      modified.map { |fn| process_event(Pathname(fn)) }
+      added.map { |fn| process_event(Pathname(fn)) }
+      removed.map { |fn| logger.debug "Ignoring removed event for #{fn}" }
+    end
+  end
+
+  ##
+  # Starts the listener process as a daemon
+  def start
+    logger.info("Starting listener")
+    run_delta
+    listen_for_changes # does not return until an Exception/Signal happens
+  ensure
+    remove_pid_file
+  end
+
+  ##
+  # Stops the listener process and cleans up pid file
+  def stop
+    logger.info("Stopping listener")
+    if running?
+      begin
+        Process.kill('TERM', pid)
+      rescue Errno::ESRCH
+        return # process doesn't exist
+      end
+    end
+  ensure
+    remove_pid_file
+  end
+
+  ##
+  # @return [Integer|Nil] reads `pid` from the `pid_file` if not set
+  def pid
+    @pid ||= begin
+      pid_file.read.to_i
+    rescue Errno::ENOENT
+      nil
+    end
+  end
+
+  ##
+  # @return [Boolean] is the listener process already running?
+  def running?
+    pid ? Process.kill(0, pid) : false
+  rescue Errno::ESRCH
+    false
+  end
+
+  private
+
+    ##
+    # runs a `find:all` process to catch up since the last time the
+    # listener process was active.
+    def run_delta
+      mins_ago = ListenerLog.minutes_since_last_active
+      if mins_ago.nil?
+        logger.warn('WARNING: Must run "rake find:all" as listener has never done any work')
+      else
+        run_find_all(mins_ago)
+      end
+    end
+
+    ##
+    # Uses the `listen` gem to monitor the "dropbox" folder for changes.
+    # Daemonizes the process and child does not return until SignalException.
+    # @return does not return -- blocks on a `sleep`
+    def listen_for_changes
+      logger.info("Listening to #{path}")
+      listener = Listen.to(path,
+                           force_polling: true, # because on NFS mount
+                           ignore: [/\.lock$/],
+                           &event_handler)
+      Process.daemon(true)
+      @pid = $PROCESS_ID
+      write_pid_file
+      Process.setproctitle('[purl-fetcher-listener]')
+      ListenerLog.create(process_id: pid, started_at: Time.current)
+      listener.start
+      sleep # wait forever -- work is done by `event_handler`
+    end
+
+    ##
+    # processes the listener file event -- assumes only adds and changes
+    # @param [Pathname] file that was added or changed
+    def process_event(fn)
+      mark_active
+      druid = fn.basename.to_s
+      if DruidTools::Druid.valid?(druid)
+        elapsed_time = Benchmark.realtime do
+          begin
+            process_druid_file(fn, druid)
+          rescue => e
+            logger.error("Cannot process #{druid}: #{e.message}")
+            Honeybadger.notify(e) # backtrace is available there
+            return
+          end
+        end
+        logger.info("Processed #{druid} in #{elapsed_time} seconds")
+      else
+        logger.warn("Ignoring miscellaneous file #{fn}")
+      end
+    end
+
+    ##
+    # actually do the work to save the PURL based on the `public` file
+    # uses `.lock` files in case the same druid is published during the
+    # time we run the save. On exception, we leave the .lock file as-is.
+    # @param [Pathname] `fn` the event file
+    # @param [String] `druid`
+    def process_druid_file(fn, druid)
+      lockfile = fn.sub_ext('.lock')
+      fn.rename(lockfile.to_s)
+      Purl.save_from_public_xml(purl_path(druid))
+      lockfile.delete
+    end
+
+    def remove_pid_file
+      pid_file.delete if pid_file.exist?
+    end
+
+    def write_pid_file
+      pid_file.write(@pid.to_s)
+    end
+
+    def run_find_all(mins_ago)
+      system("rake find:all[#{mins_ago}] </dev/null >/dev/null 2>/dev/null &") # daemonize
+    end
+
+    def purl_path(druid)
+      PurlFinder.new.purl_path(druid)
+    end
+
+    def mark_active
+      log = ListenerLog.current
+      log.active_at = Time.current
+      log.save!
+    end
+end

--- a/lib/tasks/listener.rake
+++ b/lib/tasks/listener.rake
@@ -1,0 +1,38 @@
+require 'purl_listener'
+
+namespace :listener do
+  namespace :log do
+    desc 'Clear log data'
+    task :clear do
+      Rake::Task['listener:stop'].invoke
+      ListenerLog.destroy_all
+    end
+  end
+
+  desc 'Start the listener'
+  task :start => :environment do |_t, args|
+    begin
+      PurlListener.new.start
+    rescue SignalException => e
+      puts "Listener stopped via signal #{e.message}"
+    end
+  end
+
+  desc 'Stop the listener'
+  task :stop => :environment do
+    PurlListener.new.stop
+  end
+
+  desc 'Status of the listener'
+  task :status => :environment do
+    listener = PurlListener.new
+    if listener.running?
+      system("ps -ww -F -p #{listener.pid}")
+    else
+      puts "Listener is not running"
+    end
+  end
+
+  desc 'Restart the listener'
+  task :restart => [:stop, :start]
+end

--- a/spec/features/purl_finder_spec.rb
+++ b/spec/features/purl_finder_spec.rb
@@ -32,7 +32,7 @@ describe PurlFinder do
     end
 
     it 'returns the path the deletes directory as a string and has the correct location' do
-      expect(purl_finder.path_to_deletes_dir).to eq('/purl/document_cache/.deletes')
+      expect(purl_finder.path_to_deletes_dir).to match /\.deletes/
       expect(purl_finder.path_to_deletes_dir.class).to eq(String)
     end
 

--- a/spec/features/purl_listener_spec.rb
+++ b/spec/features/purl_listener_spec.rb
@@ -1,0 +1,190 @@
+require 'rails_helper'
+
+describe PurlListener do
+  context '.initialize' do
+    it 'using the correct path' do
+      expect(subject.path).to eq Pathname(PurlFetcher::Application.config.app_config['listener_path'])
+    end
+    it 'using the correct pid_file' do
+      expect(subject.pid_file).to eq Pathname(PurlFetcher::Application.config.app_config['listener_pid_file'])
+    end
+    it 'using the correct logger' do
+      expect(subject.logger).to eq IndexingLogger
+    end
+    it 'has an event handler' do
+      expect(subject.event_handler).to be_an Proc
+    end
+  end
+
+  context '.start' do
+    it 'starts listening for the very first time' do
+      expect(subject.logger).to receive(:info).with(/Starting/)
+
+      # check that we are indeed running for the first time
+      expect(ListenerLog).to receive(:minutes_since_last_active).and_return(nil)
+      expect(subject.logger).to receive(:warn).with(/listener has never done any work/)
+      expect(subject).not_to receive(:run_find_all)
+
+      # check that the listener is started
+      expect(subject).to receive(:listen_for_changes)
+      expect(subject).to receive(:remove_pid_file)
+      subject.start
+    end
+
+    it 'runs delta rake if listener was previously active' do
+      expect(subject.logger).to receive(:info).with(/Starting/)
+
+      # check that we are running for the nth time
+      expect(ListenerLog).to receive(:minutes_since_last_active).and_return(123)
+      expect(subject).to receive(:run_find_all).with(123)
+
+      # check that the listener is started
+      expect(subject).to receive(:listen_for_changes)
+      subject.start
+    end
+
+    it 'cleans up pid file on Exception' do
+      expect(subject.logger).to receive(:info).with(/Starting/)
+      expect(subject).to receive(:run_delta)
+      expect(subject).to receive(:listen_for_changes).and_raise(SignalException.new('TERM'))
+      expect(subject).to receive(:remove_pid_file)
+      expect { subject.start }.to raise_error(SignalException)
+    end
+  end
+
+  context '.stop' do
+    before do
+      expect(subject.logger).to receive(:info).with(/Stopping/)
+    end
+
+    it 'does nothing if the listener is not running' do
+      expect(subject).to receive(:'running?').and_return(false)
+      subject.stop
+    end
+    it 'sends signal if the listener is running' do
+      expect(subject).to receive(:'running?').and_return(true)
+      expect(subject).to receive(:pid).and_return(123)
+      expect(Process).to receive(:kill).with(/TERM/, 123)
+      subject.stop
+    end
+    it 'cleans up pid_file the pid from the file is no longer a process' do
+      expect(subject).to receive(:'running?').and_return(true)
+      expect(subject).to receive(:pid).and_return(123)
+      expect(Process).to receive(:kill).with(/TERM/, 123).and_raise(Errno::ESRCH)
+      expect(subject.pid_file).to receive(:exist?).and_return(true)
+      expect(subject.pid_file).to receive(:delete)
+      subject.stop
+    end
+    it 'cleans up orphaned pid_file' do
+      expect(subject).to receive(:'running?').and_return(false)
+      expect(subject.pid_file).to receive(:exist?).and_return(true)
+      expect(subject.pid_file).to receive(:delete)
+      subject.stop
+    end
+  end
+
+  context '.running?' do
+    it 'returns false when not running' do
+      expect(subject.running?).to be_falsey
+    end
+    it 'returns true when running' do
+      subject.instance_variable_set(:@pid, $PID)
+      expect(subject.running?).to be_truthy
+    end
+    it 'returns false when pid is set but not running' do
+      subject.instance_variable_set(:@pid, $PID)
+      expect(Process).to receive(:kill).with(0, $PID).and_raise(Errno::ESRCH)
+      expect(subject.running?).to be_falsey
+    end
+  end
+
+  context '.pid' do
+    it 'returns nil when no pid_file' do
+      expect(subject.pid_file).to receive(:read).and_raise(Errno::ENOENT.new)
+      expect(subject.pid).to be_nil
+    end
+    it 'returns value of pid_file' do
+      expect(subject.pid_file).to receive(:read).and_return('123')
+      expect(subject.pid).to eq 123
+    end
+  end
+
+  context '.listen_for_changes' do
+    # rubocop:disable RSpec/AnyInstance
+    before do
+      allow_any_instance_of(Object).to receive(:sleep).with(no_args).and_raise(SignalException.new('TERM'))
+    end
+    # rubocop:enable RSpec/AnyInstance
+
+    it 'calls Listen.to and daemonize into sleep-based infinite loop' do
+      expect(subject.logger).to receive(:info).with(/Listening to/)
+      expect(Listen).to receive(:to).and_return(double(start: nil))
+      expect(Process).to receive(:daemon)
+      expect(subject.pid_file).to receive(:write).with($PROCESS_ID.to_s)
+      expect(Process).to receive(:setproctitle).with(/purl-fetcher-listener/)
+      expect(ListenerLog).to receive(:create)
+      expect { subject.send(:listen_for_changes) }.to raise_error(SignalException)
+    end
+  end
+
+  context 'processing files' do
+    let(:druid) { 'aa111bb2222' }
+    let(:fn) { Pathname("/no/where/#{druid}") }
+    before do
+      ListenerLog.create(process_id: $PID, started_at: Time.now - 1)
+    end
+
+    context '.process_event' do
+      it 'should parse a valid druid from the filename and mark active' do
+        expect(subject).to receive(:process_druid_file).with(fn, druid)
+        expect(subject.logger).to receive(:info).with(/Processed/)
+        subject.send(:process_event, fn)
+        expect(ListenerLog.current.active_at).to be_an Time
+      end
+      it 'should log exceptions correctly' do
+        expect(subject).to receive(:process_druid_file).and_raise(StandardError.new)
+        expect(subject.logger).to receive(:error).with(/Cannot process/)
+        expect(Honeybadger).to receive(:notify)
+        subject.send(:process_event, fn)
+      end
+      it 'should skip filenames that are not druids' do
+        expect(subject).not_to receive(:process_druid_file)
+        expect(subject.logger).to receive(:warn).with(/Ignoring miscellaneous/)
+        subject.send(:process_event, Pathname('/no/where/not_a_druid'))
+      end
+    end
+    context '.process_druid_file' do
+      it 'should parse the druid from the filename' do
+        expect(fn).to receive(:rename).with("#{fn}.lock")
+        expect(PurlFinder).to receive(:new).and_return(double(purl_path: '/some/place'))
+        expect(Purl).to receive(:save_from_public_xml)
+        expect_any_instance_of(Pathname).to receive(:delete)
+        subject.send(:process_druid_file, fn, druid)
+      end
+    end
+  end
+
+  context '.run_find_all' do
+    # rubocop:disable RSpec/AnyInstance
+    it 'runs a rake task' do
+      allow_any_instance_of(Object).to receive(:system).with(/rake find:all\[1\].*&$/)
+      subject.send(:run_find_all, 1)
+    end
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  context '.event_handler' do
+    it 'processes adds' do
+      expect(subject).to receive(:process_event)
+      subject.event_handler.call([], ['abc'], [])
+    end
+    it 'processes modified' do
+      expect(subject).to receive(:process_event)
+      subject.event_handler.call(['abc'], [], [])
+    end
+    it 'ignores deletes' do
+      expect(subject.logger).to receive(:debug).with(/Ignoring/)
+      subject.event_handler.call([], [], ['abc'])
+    end
+  end
+end

--- a/spec/models/listener_log_spec.rb
+++ b/spec/models/listener_log_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe ListenerLog do
+  context 'without any prior listeners' do
+    it 'has no current process' do
+      expect(described_class.current).to be_nil
+    end
+    it 'has no minutes_since_last_started' do
+      expect(described_class.minutes_since_last_started).to be_nil
+    end
+    it 'has no minutes_since_last_active' do
+      expect(described_class.minutes_since_last_active).to be_nil
+    end
+  end
+  context 'with a prior inactive listeners' do
+    before do
+      described_class.create(process_id: 123, started_at: Time.now - 1)
+    end
+    it 'has current process' do
+      expect(described_class.current).to be_an ListenerLog
+    end
+    it 'has minutes_since_last_started' do
+      expect(described_class.minutes_since_last_started).to be_an Integer
+      expect(described_class.minutes_since_last_started).to be > 0
+    end
+    it 'has no minutes_since_last_active' do
+      expect(described_class.minutes_since_last_active).to be_nil
+    end
+  end
+  context 'with a prior active listeners' do
+    before do
+      described_class.create(process_id: 123, started_at: Time.now - 1, active_at: Time.now)
+    end
+    it 'has current process' do
+      expect(described_class.current).to be_an ListenerLog
+    end
+    it 'has minutes_since_last_started' do
+      expect(described_class.minutes_since_last_started).to be_an Integer
+      expect(described_class.minutes_since_last_started).to be > 0
+    end
+    it 'has minutes_since_last_active' do
+      expect(described_class.minutes_since_last_active).to be_an Integer
+      expect(described_class.minutes_since_last_active).to be > 0
+    end
+  end
+end


### PR DESCRIPTION
Paired with @eefahy on this PR.

This PR fixes #66 and fixes #106 by adding `PurlListener` to support incremental indexing. The listener is a daemon process and includes the `listener:start/stop/restart/status` tasks. A `cap deploy` and `cap deploy:restart` will restart the listener daemon.

See https://github.com/sul-dlss/purl-fetcher/issues/66#issuecomment-239324781 for a discussion of the basic algorithm.

**NOTE**: That this PR requires puppet changes before deployment. Right now only the `-dev` environment has those changes.