### PR TITLE
drop ruby 2.1.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: ruby
 cache: bundler
 script: bundle exec rake travis_ci 
 rvm:
-  - 2.1.2 # deployed
-  - 2.3.1 
+  - 2.3.1 # deployed
 notifications:
   email:
     - pmangiafico@stanford.edu


### PR DESCRIPTION
The `listen` gem requires > 2.1.2 to work. Our VMs are all running 2.3 now.