### PR TITLE
README: Omit documentation rake tasks and use rspec for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,6 @@ There are three log files:
 
 ## Running tests
 
-### To run the tests
-
 ```bash
-bundle exec rake
-```
-
-This command will run all of the tests, run rubocop and generate new documentation.
-
-## Generate documentation
-
-To generate documentation into the "doc" folder:
-
-```bash
-yard
-```
-
-To keep a local server running with up to date code documentation that you can view in your browser:
-
-```bash
-yard server --reload
+bundle exec rspec
 ```


### PR DESCRIPTION
Suggests to use `rspec` rather than `rake purl_fetcher:spec` which is what `rake ci` uses. Do we want to promote uses of `rake ci` as the way to run the tests for a developer? I dunno...