### PR TITLE
PURL deleted_at timestamp should come from .deletes touch file

### DIFF
--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -43,11 +43,12 @@ class Purl < ActiveRecord::Base
   # Specify an instance's `deleted_at` attribute which denotes when an object's
   # public xml is gone
   # @param [String] druid
-  def self.trigger_deleted_at(druid)
+  # @param [Time] `deleted_at` the time at which the PURL was deleted. If `nil`, it uses the current time.
+  def self.mark_deleted(druid, deleted_at = nil)
     druid = "druid:#{druid}" unless druid.include?('druid:') # add the druid prefix if it happens to be missing
     purl = find_or_create_by(druid: druid) # either create a new druid record or get the existing one
     #  (in theory we should *always* have a previous druid here)
-    purl.deleted_at = Time.zone.now
+    purl.deleted_at = deleted_at.nil? ? Time.current : deleted_at
     purl.save
   end
 end

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -1,21 +1,34 @@
 require 'rails_helper'
 
 describe Purl, type: :model do
-  it 'indicates when a record is deleted' do
-    purl = described_class.create(druid: 'oo000oo0001')
-    expect(purl.deleted_at?).to be_falsey
-    purl.deleted_at = Time.zone.now
-    purl.save
-    expect(purl.deleted_at?).to be_truthy
+  let (:druid) { 'druid:bb050dj7711' }
+  describe '.mark_deleted' do
+    it 'always starts without deleted_at time' do
+      purl = described_class.create(druid: druid)
+      expect(purl.deleted_at?).to be_falsey
+    end
+    it 'marks a record as deleted' do
+      expect(described_class.mark_deleted(druid)).to be_truthy
+      purl = described_class.find_by_druid(druid)
+      expect(purl.deleted_at?).to be_truthy
+    end
+    it 'marks a record as deleted with a given timestamp' do
+      deleted_at_time = Time.current
+      expect(described_class.mark_deleted(druid, deleted_at_time)).to be_truthy
+      purl = described_class.find_by(druid: druid)
+      expect(purl.deleted_at.iso8601).to eq deleted_at_time.iso8601 # favorable compare which removes milliseconds
+    end
   end
   describe '.save_from_public_xml' do
-    let(:druid_path) { DruidTools::PurlDruid.new('bb050dj6667', purl_fixture_path).path }
+    let(:purl_path) { DruidTools::PurlDruid.new(druid, purl_fixture_path).path }
     it 'does not create duplication Collection or relationships' do
+      n = 2
       expect do
-        described_class.save_from_public_xml(sample_doc_path)
-        described_class.save_from_public_xml(sample_doc_path)
-      end.to change{ Collection.all.count }.by(2)
-      expect(described_class.find_by_druid('druid:bb050dj7711').collections.count).to eq 2
+        n.times do
+          described_class.save_from_public_xml(purl_path)
+        end
+      end.to change{ Collection.all.count }.by(n)
+      expect(described_class.find_by_druid(druid).collections.count).to eq n
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require 'coveralls'
 Coveralls.wear!('rails')
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
This PR fixes #124, the `deleted_at` data problem discussed in https://github.com/sul-dlss/discovery-indexing/issues/20.

- Renames `Purl.trigger_deleted_at` to `Purl.mark_deleted` and adds an optional timestamp argument
- Changes `PurlFinder` to use the timestamp of the .deletes touch file
- Updates specs for new signatures, including some code clarity cleanup
- Adds new specs for `Purl` to test `mark_deleted` correctly

tested in -dev