### PR TITLE
datetimes just need to be in iso8601 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The `/docs/changes` endpoint provides information about public PURL documents th
 ##### Parameters
 Name | Located In | Description | Required | Schema | Default
 ---- | ---------- | ----------- | -------- | ------ | -------
-`first_modified` | query | Limit response by a beginning datetime | No | datetime in UTC iso8601 | earliest possible date
-`last_modified` | query | Limit response by an ending datetime| No | datetime in UTC iso8601 | current time
+`first_modified` | query | Limit response by a beginning datetime | No | datetime in iso8601 | earliest possible date
+`last_modified` | query | Limit response by an ending datetime| No | datetime in iso8601 | current time
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
 
@@ -113,8 +113,8 @@ The `/docs/deletes` endpoint provides information about public PURL documents th
 ##### Parameters
 Name | Located In | Description | Required | Schema | Default
 ---- | ---------- | ----------- | -------- | ------ | -------
-`first_modified` | query | Limit response by a beginning datetime | No | datetime in UTC iso8601 | earliest possible date
-`last_modified` | query | Limit response by an ending datetime| No | datetime in UTC iso8601 | current time
+`first_modified` | query | Limit response by a beginning datetime | No | datetime in iso8601 | earliest possible date
+`last_modified` | query | Limit response by an ending datetime| No | datetime in iso8601 | current time
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
 

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -1,16 +1,7 @@
 class DocsController < ApplicationController
-
   before_action :date_params
 
   # API call to get a full list of all purls modified between two times
-  # @param [querystring] Parameters can be specified in the querystring
-  #   * first_modified = datetime in UTC (default: earliest possible date)
-  #   * last_modified = datetime in UTC (default: current time)
-  #
-  # Example:
-  #   http://localhost:3000/docs/changes  # gives all items modified from the Unix Epoch until now
-  #   http://localhost:3000/docs/changes?first_modified=2014-01-01T00:00:00Z # returns only the modified documents SINCE January of 2014 up until today in json format
-  # response is in the structure of {changes: [{druid: 'oo000oo0001', latest_change: '2015-01-01T00:00:00Z'}]}
   def changes
     @changes = Purl.where(deleted_at: nil)
                    .where(published_at: @first_modified..@last_modified)
@@ -20,13 +11,6 @@ class DocsController < ApplicationController
   end
 
   # API call to get a full list of all purl deletes between two times
-  # @param [querystring] Parameters can be specified in the querystring
-  #   * first_modified = datetime in UTC (default: earliest possible date)
-  #   * last_modified = datetime in UTC (default: current time)
-  #
-  # Example:
-  #   http://localhost:3000/docs/deletes  # gives all items deleted from the Unix Epoch until now
-  #   http://localhost:3000/docs/deletes?first_modified=2014-01-01T00:00:00Z # returns only the modified deleted SINCE January of 2014 up until today in json format
   def deletes
     @deletes = Purl.where(deleted_at: @first_modified..@last_modified)
                    .page(params[:page])


### PR DESCRIPTION
This PR updates the README and removes redundant documentation from the code. Maybe we should retain the examples in the README?