### PR TITLE
add deleted_at,published_at index to improve main query performance

### DIFF
--- a/db/migrate/20160822193508_add_purl_indexes.rb
+++ b/db/migrate/20160822193508_add_purl_indexes.rb
@@ -1,0 +1,5 @@
+class AddPurlIndexes < ActiveRecord::Migration
+  def change
+    add_index :purls, [:published_at, :deleted_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160819203202) do
+ActiveRecord::Schema.define(version: 20160822193508) do
 
   create_table "collections", force: :cascade do |t|
     t.string   "druid",      null: false
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20160819203202) do
   add_index "purls", ["deleted_at"], name: "index_purls_on_deleted_at"
   add_index "purls", ["druid"], name: "index_purls_on_druid", unique: true
   add_index "purls", ["object_type"], name: "index_purls_on_object_type"
+  add_index "purls", ["published_at", "deleted_at"], name: "index_purls_on_published_at_and_deleted_at"
   add_index "purls", ["published_at"], name: "index_purls_on_published_at"
 
   create_table "release_tags", force: :cascade do |t|


### PR DESCRIPTION
This PR is connected to #139. It adds a composite index to optimize the following query:

```sql
SELECT  `purls`.* FROM `purls` WHERE `purls`.`deleted_at` IS NULL AND 
(`purls`.`published_at` BETWEEN '2016-08-01T22:53:14Z' AND '2016-08-22T15:21:08Z')  
ORDER BY published_at LIMIT 100 OFFSET 0
```
