### PR TITLE
multiple dc:title elements should yield the first

### DIFF
--- a/lib/purl_parser.rb
+++ b/lib/purl_parser.rb
@@ -45,16 +45,12 @@ class PurlParser
     @druid ||= public_xml.at_xpath('//publicObject').attr('id')
   end
 
-  # Extract the title from publicXML DC
+  # Extract the title from publicXML DC. If there are more than 1 elements, it takes the first.
   #
-  # @return [String] Tht title of the object
+  # @return [String] The title of the object
   #
   def title
-    unless @title
-      title_node = public_xml.xpath('//*[name()="dc:title"]')
-      @title = (title_node.size == 1 ? title_node[0].content : "")
-    end
-    @title
+    @title ||= public_xml.xpath('//*[name()="dc:title"][1]').text
   end
 
   # Extract the object type

--- a/spec/features/purl_parser_spec.rb
+++ b/spec/features/purl_parser_spec.rb
@@ -63,4 +63,14 @@ describe PurlParser do
       expect(subject.modified_time).to be_an Time
     end
   end
+
+  describe('nc687px4289') do
+    let(:sample_doc_path) { DruidTools::PurlDruid.new('nc687px4289', purl_fixture_path).path }
+    let(:purl) { described_class.new(sample_doc_path) }
+
+    it 'uses the first title' do
+      expect(purl.public_xml.xpath('//*[name()="dc:title"]').size).to eq 2 # multiple titles
+      expect(purl.title).to eq('Kitaĭ')
+    end
+  end
 end

--- a/spec/purl-test-fixtures/document_cache/nc/687/px/4289/contentMetadata
+++ b/spec/purl-test-fixtures/document_cache/nc/687/px/4289/contentMetadata
@@ -1,0 +1,32 @@
+<contentMetadata objectId="nc687px4289" type="image">
+  <resource id="nc687px4289_2" sequence="2" type="image">
+    <label>kitai_nc687px4289</label>
+    <file format="JPEG2000" id="36105005851766_05_0002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes" size="8878523">
+      <imageData height="6217" width="7573"/>
+      <attr name="representation">uncropped</attr>
+      <checksum type="sha1">6bec715ad2c3378da5e4b6d09aca2df83189e430</checksum>
+      <checksum type="md5">7c81523e49284374a42a6b00ff376869</checksum>
+    </file>
+    <file format="TIFF" id="36105005851766_00_0002.tif" mimetype="image/tiff" preserve="yes" publish="no" shelve="no" size="77015660">
+      <imageData height="6217" width="7573"/>
+      <attr name="representation">uncropped</attr>
+      <checksum type="sha1">02a50da00ddf2cb3d12d0d75c6f6d6e96a5694ac</checksum>
+      <checksum type="md5">693359e42d4a27640ff88c453823e3c9</checksum>
+    </file>
+  </resource>
+  <resource id="nc687px4289_1" sequence="1" type="image">
+    <label>kitai_nc687px4289</label>
+    <file format="JPEG2000" id="36105005851766_05_0001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes" size="8778143">
+      <imageData height="6191" width="7518"/>
+      <attr name="representation">uncropped</attr>
+      <checksum type="sha1">d0675713f903180e9bc24aadfe017d0f3c15e852</checksum>
+      <checksum type="md5">ec6b8a00e9db94de8e4be775e0498e60</checksum>
+    </file>
+    <file format="TIFF" id="36105005851766_00_0001.tif" mimetype="image/tiff" preserve="yes" publish="no" shelve="no" size="109312790">
+      <imageData height="6191" width="7518"/>
+      <attr name="representation">uncropped</attr>
+      <checksum type="sha1">83120ec8246d07bff74e0163b84e0d5fedf8c23c</checksum>
+      <checksum type="md5">f03fa626fa92f5c573696af74c070966</checksum>
+    </file>
+  </resource>
+</contentMetadata>

--- a/spec/purl-test-fixtures/document_cache/nc/687/px/4289/dc
+++ b/spec/purl-test-fixtures/document_cache/nc/687/px/4289/dc
@@ -1,0 +1,31 @@
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Kita&#x12D;</dc:title>
+  <dc:title>China</dc:title>
+  <dc:creator>Soviet Union Sovetskai&#x361;a Armii&#x361;a. General&#x2B9;ny&#x12D; shtab.</dc:creator>
+  
+  <dc:type>map</dc:type>
+  <dc:date>1968-9999</dc:date><dc:publisher>General&#x2B9;ny&#x12D; shtab</dc:publisher>
+  <dc:language>rus</dc:language>
+  <dc:format>maps : col. ; 37 x 53 cm. or smaller.</dc:format><dc:format>map</dc:format>
+  <dc:description>Military topographic maps.</dc:description>
+  <dc:description>Relief shown by contours and spot heights. Depths shown by contours and soundings on some sheets.</dc:description>
+  <dc:description>Name of jurisdiction[s] covered by sheet quadrangle appears in upper margin at left, e.g.: Provint&#x361;sii&#x361;a Guandun -- Avtonomny&#x12D; ra&#x12D;on Vnutrenni&#x361;ai&#x361;a Mongolii&#x361;a, Provint&#x361;sii Kh&#x117;b&#x117;&#x12D;, Shan&#x2B9;si. May include name and province of neighboring country.</dc:description>
+  <dc:description>Common title precedes jurisdiction name at upper left on each sheet.</dc:description>
+  <dc:description>Sheets individually subtitled and numbered (with roman-alphabet lettering) in upper margin, e.g.: Ch&#x117;nma&#x12D;, E-49-III -- Sich&#x117;n, K-50-XXXI.</dc:description>
+  <dc:description>Ed./publication date in upper border at right, e.g.: Izdanie 1970 g. -- Izdanie 1986 g. -- Izdanie 1991 g.</dc:description>
+  <dc:description>Former security classification in upper margin at right: Sekretno.</dc:description>
+  <dc:description>Includes notes, diagrams, compilation date[s], and sheet compiler's/editor's names in lower margin.</dc:description>
+  <dc:description>Blue sheet no. in upper margin precedes black sheet no., e.g.: 05-49-01 -- 11-50-31.</dc:description>
+  <dc:description>Text and ancillary map, "Skhema gruntov," on verso.</dc:description>
+  <dc:description>In Russian.</dc:description>
+  
+  <dc:subject/><dc:coverage>Scale 1:200,000. 1 cm. to 2 km.</dc:coverage><dc:coverage>98.0,24.666667 
+99.0,24.666667 
+99.0,24.0 
+98.0,24.0 
+98.0,24.666667
+</dc:coverage><dc:coverage>Pulkovo 1942</dc:coverage>
+  <dc:subject>Military maps</dc:subject>
+  <dc:subject/><dc:coverage>China</dc:coverage>
+  
+</oai_dc:dc>

--- a/spec/purl-test-fixtures/document_cache/nc/687/px/4289/identityMetadata
+++ b/spec/purl-test-fixtures/document_cache/nc/687/px/4289/identityMetadata
@@ -1,0 +1,9 @@
+<identityMetadata>
+  <adminPolicy>druid:xs835jp8197</adminPolicy>
+  <objectCreator>DOR</objectCreator>
+  <objectId>druid:nc687px4289</objectId>
+  <objectLabel>Kitai_nc687px4289</objectLabel>
+  <objectType>item</objectType>
+  <otherId name="uuid">8dd83a1c-22e3-11e1-8364-0016034322e6</otherId>
+  <tag>Project : Kitai</tag>
+</identityMetadata>

--- a/spec/purl-test-fixtures/document_cache/nc/687/px/4289/public
+++ b/spec/purl-test-fixtures/document_cache/nc/687/px/4289/public
@@ -1,0 +1,73 @@
+<publicObject id="druid:nc687px4289" published="2011-12-15T14:15:46-08:00">
+  <identityMetadata>
+    <adminPolicy>druid:xs835jp8197</adminPolicy>
+    <objectCreator>DOR</objectCreator>
+    <objectId>druid:nc687px4289</objectId>
+    <objectLabel>Kitai_nc687px4289</objectLabel>
+    <objectType>item</objectType>
+    <otherId name="uuid">8dd83a1c-22e3-11e1-8364-0016034322e6</otherId>
+    <tag>Project : Kitai</tag>
+  </identityMetadata>
+  <contentMetadata objectId="nc687px4289" type="image">
+    <resource id="nc687px4289_2" sequence="2" type="image">
+      <label>kitai_nc687px4289</label>
+      <file format="JPEG2000" id="36105005851766_05_0002.jp2" mimetype="image/jp2" size="8878523">
+        <imageData height="6217" width="7573"/>
+        <attr name="representation">uncropped</attr>
+      </file>
+    </resource>
+    <resource id="nc687px4289_1" sequence="1" type="image">
+      <label>kitai_nc687px4289</label>
+      <file format="JPEG2000" id="36105005851766_05_0001.jp2" mimetype="image/jp2" size="8778143">
+        <imageData height="6191" width="7518"/>
+        <attr name="representation">uncropped</attr>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <group>stanford</group>
+      </machine>
+    </access>
+  </rightsMetadata>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Kita&#x12D;</dc:title>
+    <dc:title>China</dc:title>
+    <dc:creator>Soviet Union Sovetskai&#x361;a Armii&#x361;a. General&#x2B9;ny&#x12D; shtab.</dc:creator>
+    <dc:type>map</dc:type>
+    <dc:date>1968-9999</dc:date>
+    <dc:publisher>General&#x2B9;ny&#x12D; shtab</dc:publisher>
+    <dc:language>rus</dc:language>
+    <dc:format>maps : col. ; 37 x 53 cm. or smaller.</dc:format>
+    <dc:format>map</dc:format>
+    <dc:description>Military topographic maps.</dc:description>
+    <dc:description>Relief shown by contours and spot heights. Depths shown by contours and soundings on some sheets.</dc:description>
+    <dc:description>Name of jurisdiction[s] covered by sheet quadrangle appears in upper margin at left, e.g.: Provint&#x361;sii&#x361;a Guandun -- Avtonomny&#x12D; ra&#x12D;on Vnutrenni&#x361;ai&#x361;a Mongolii&#x361;a, Provint&#x361;sii Kh&#x117;b&#x117;&#x12D;, Shan&#x2B9;si. May include name and province of neighboring country.</dc:description>
+    <dc:description>Common title precedes jurisdiction name at upper left on each sheet.</dc:description>
+    <dc:description>Sheets individually subtitled and numbered (with roman-alphabet lettering) in upper margin, e.g.: Ch&#x117;nma&#x12D;, E-49-III -- Sich&#x117;n, K-50-XXXI.</dc:description>
+    <dc:description>Ed./publication date in upper border at right, e.g.: Izdanie 1970 g. -- Izdanie 1986 g. -- Izdanie 1991 g.</dc:description>
+    <dc:description>Former security classification in upper margin at right: Sekretno.</dc:description>
+    <dc:description>Includes notes, diagrams, compilation date[s], and sheet compiler's/editor's names in lower margin.</dc:description>
+    <dc:description>Blue sheet no. in upper margin precedes black sheet no., e.g.: 05-49-01 -- 11-50-31.</dc:description>
+    <dc:description>Text and ancillary map, "Skhema gruntov," on verso.</dc:description>
+    <dc:description>In Russian.</dc:description>
+    <dc:subject/>
+    <dc:coverage>Scale 1:200,000. 1 cm. to 2 km.</dc:coverage>
+    <dc:coverage>98.0,24.666667 
+99.0,24.666667 
+99.0,24.0 
+98.0,24.0 
+98.0,24.666667
+</dc:coverage>
+    <dc:coverage>Pulkovo 1942</dc:coverage>
+    <dc:subject>Military maps</dc:subject>
+    <dc:subject/>
+    <dc:coverage>China</dc:coverage>
+  </oai_dc:dc>
+</publicObject>

--- a/spec/purl-test-fixtures/document_cache/nc/687/px/4289/rightsMetadata
+++ b/spec/purl-test-fixtures/document_cache/nc/687/px/4289/rightsMetadata
@@ -1,0 +1,12 @@
+<rightsMetadata>
+  <access type="discover">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <group>stanford</group>
+    </machine>
+  </access>
+</rightsMetadata>


### PR DESCRIPTION
This PR fixes #148. It's implemented using a single XPath expression and adds a new fixture that has 2 dc:titles. If `dc:title` is missing then the `title` is `""`.