### PR TITLE
handle race condition when pid file is missing suddenly

### DIFF
--- a/lib/purl_listener.rb
+++ b/lib/purl_listener.rb
@@ -156,7 +156,9 @@ class PurlListener
     end
 
     def remove_pid_file
-      pid_file.delete if pid_file.exist?
+      pid_file.delete
+    rescue Errno::ENOENT
+      # no pid file
     end
 
     def write_pid_file

--- a/spec/features/purl_listener_spec.rb
+++ b/spec/features/purl_listener_spec.rb
@@ -71,14 +71,12 @@ describe PurlListener do
       expect(subject).to receive(:'running?').and_return(true)
       expect(subject).to receive(:pid).and_return(123)
       expect(Process).to receive(:kill).with(/TERM/, 123).and_raise(Errno::ESRCH)
-      expect(subject.pid_file).to receive(:exist?).and_return(true)
       expect(subject.pid_file).to receive(:delete)
       subject.stop
     end
     it 'cleans up orphaned pid_file' do
       expect(subject).to receive(:'running?').and_return(false)
-      expect(subject.pid_file).to receive(:exist?).and_return(true)
-      expect(subject.pid_file).to receive(:delete)
+      expect(subject.pid_file).to receive(:delete).and_raise(Errno::ENOENT)
       subject.stop
     end
   end


### PR DESCRIPTION
This PR fixes #150 by avoiding the race condition of `exist?` vs. `delete` and just calls `.delete` outright and handles the exception if the file is missing.