### PR TITLE
enforce uniqueness of ReleaseTag name,purl_id composite

### DIFF
--- a/app/models/release_tag.rb
+++ b/app/models/release_tag.rb
@@ -1,5 +1,21 @@
 class ReleaseTag < ActiveRecord::Base
-
   belongs_to :purl
+  validates :name, uniqueness: { scope: :purl_id }
 
+  ##
+  # Locates an existing ReleaseTag record and sets the release_type as given
+  #
+  # @param [Purl] `purl`
+  # @param [String] `name` release tag name
+  # @param [Boolean] `release_type`
+  # @return [ReleaseTag] finds or creates a ReleaseTag record for the given tuple
+  def self.for(purl, name, release_type)
+    tag = ReleaseTag.find_by(name: name, purl_id: purl.id)
+    if tag.present?
+      tag.release_type = release_type
+    else
+      tag = ReleaseTag.create(name: name, purl_id: purl.id, release_type: release_type)
+    end
+    tag
+  end
 end

--- a/db/migrate/20160823121748_enforce_unique_release_tags.rb
+++ b/db/migrate/20160823121748_enforce_unique_release_tags.rb
@@ -1,0 +1,5 @@
+class EnforceUniqueReleaseTags < ActiveRecord::Migration
+  def change
+    add_index :release_tags, [ :name, :purl_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160822193508) do
+ActiveRecord::Schema.define(version: 20160823121748) do
 
   create_table "collections", force: :cascade do |t|
     t.string   "druid",      null: false
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20160822193508) do
     t.datetime "updated_at",   null: false
   end
 
+  add_index "release_tags", ["name", "purl_id"], name: "index_release_tags_on_name_and_purl_id", unique: true
   add_index "release_tags", ["purl_id"], name: "index_release_tags_on_purl_id"
   add_index "release_tags", ["release_type"], name: "index_release_tags_on_release_type"
 

--- a/spec/models/release_tag_spec.rb
+++ b/spec/models/release_tag_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe ReleaseTag do
+  let(:purl) { Purl.find(1) }
+  context 'reads data correctly' do
+    it '.release_tags' do
+      tags = Hash[purl.release_tags.collect { |tag| [ tag.name, tag.release_type ] }]
+      expect(tags).to include('Revs' => true, 'SearchWorks' => true)
+    end
+  end
+  context 'updates duplicate tags correctly' do
+    it 'finds prior tags using unique composite key' do
+      tag = described_class.find_by(purl_id: purl.id, name: 'Revs')
+      expect(tag).to be_an described_class
+    end
+    it 'enforces uniqueness for composite key' do
+      tag = described_class.create(purl_id: purl.id, name: 'SomethingWonderful', release_type: false)
+      tag = described_class.create(purl_id: purl.id, name: 'SomethingWonderful', release_type: true) # again
+      expect { tag.save! }.to raise_error(ActiveRecord::RecordInvalid, /Name has already been taken/)
+    end
+    context '.for' do
+      it 'will overwrite prior tags' do
+        tag = described_class.for(purl, 'Revs', false)
+        expect(tag.release_type).to be_falsey     # sets type
+        expect(tag.new_record?).to be_falsey      # reuses
+        expect(tag.changed?).to be_truthy         # not saved
+        expect { tag.save! }.not_to raise_error   # saves ok
+      end
+      it 'will create new tags' do
+        expect(described_class.find_by(purl_id: purl.id, name: 'SomethingWonderful')).to be_nil
+        expect(described_class.for(purl, 'SomethingWonderful', false)).to be_an described_class
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes #152.

**NOTE** that a `db:migrate` *might* fail with this PR as it adds a new unique key to the database schema. If that's the case you can either reset the database via  `rake db:reset` or try to clean up the data manually (not recommended).