### PR TITLE
add rubocop to default travis build; simply rake tasks so we do not h…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ Style/EmptyLineBetweenDefs:
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
   Max: 200
+Metrics/AbcSize:
+  Max: 30
 
 AllCops:
   TargetRubyVersion: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 cache: bundler
-script: bundle exec rake travis_ci
+script: bundle exec rake ci
 rvm:
   - 2.3.1 # deployed
 notifications:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are three log files:
 ## Running tests
 
 ```bash
-bundle exec rspec
+bundle exec rake
 ```
 
 ## API Provided (as implemented)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,11 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def page_params
-    params.permit(:page)
-  end
+    def page_params
+      params.permit(:page)
+    end
 
-  def per_page_params
-    params.permit(:per_page)
-  end
+    def per_page_params
+      params.permit(:per_page)
+    end
 end

--- a/app/controllers/v1/docs_controller.rb
+++ b/app/controllers/v1/docs_controller.rb
@@ -21,13 +21,13 @@ module V1
 
     private
 
-    def date_params
-      @first_modified = params[:first_modified] || Time.zone.at(0).iso8601
-      @last_modified = params[:last_modified] || Time.zone.now.iso8601
-    end
+      def date_params
+        @first_modified = params[:first_modified] || Time.zone.at(0).iso8601
+        @last_modified = params[:last_modified] || Time.zone.now.iso8601
+      end
 
-    def per_page_params
-      params.permit(:per_page)
-    end
+      def per_page_params
+        params.permit(:per_page)
+      end
   end
 end

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -18,16 +18,16 @@ module V1
 
     private
 
-    def filter_params
-      object_type_param
-    end
+      def filter_params
+        object_type_param
+      end
 
-    def object_type_param
-      params.permit(:object_type)
-    end
+      def object_type_param
+        params.permit(:object_type)
+      end
 
-    def druid_param
-      params.require(:druid)
-    end
+      def druid_param
+        params.require(:druid)
+      end
   end
 end

--- a/lib/purl_listener.rb
+++ b/lib/purl_listener.rb
@@ -160,7 +160,7 @@ class PurlListener
     def remove_pid_file
       pid_file.delete
     rescue Errno::ENOENT
-      # no pid file
+      logger.info("no PID file")
     end
 
     def write_pid_file

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -14,15 +14,11 @@ namespace :purl_fetcher do
 end
 
 desc 'Run continuous integration suite (tests, coverage, rubocop)'
-task :ci => :travis_ci do
-   Rake::Task['rubocop'].invoke
-end
-
-desc 'Run continuous integration suite without rubocop for travis'
-task :travis_ci do
+task :ci do
   system('RAILS_ENV=test rake db:migrate')
   system('RAILS_ENV=test rake db:test:prepare')
   Rake::Task['purl_fetcher:spec'].invoke
+  Rake::Task['rubocop'].invoke
 end
 
 desc 'Run rubocop on ruby files'

--- a/spec/constraints/api_constraints_spec.rb
+++ b/spec/constraints/api_constraints_spec.rb
@@ -4,7 +4,7 @@ describe ApiConstraint do
   describe '#matches' do
     context 'when less than version specified' do
       it 'does not match' do
-        request = double('a request', headers: {'HTTP_ACCEPT' => 'version=1'})
+        request = double('a request', headers: { 'HTTP_ACCEPT' => 'version=1' })
         expect(described_class.new(version: 2).matches?(request)).to be false
       end
     end
@@ -16,7 +16,7 @@ describe ApiConstraint do
     end
     context 'when greater than version specified' do
       it 'matches to 1' do
-        request = double('a request', headers: {'HTTP_ACCEPT' => 'version=2'})
+        request = double('a request', headers: { 'HTTP_ACCEPT' => 'version=2' })
         expect(described_class.new(version: 1).matches?(request)).to be true
       end
     end

--- a/spec/features/docs_controller_spec.rb
+++ b/spec/features/docs_controller_spec.rb
@@ -21,7 +21,7 @@ describe(V1::DocsController, type: :request, integration: true) do
       [
         { druid: "druid:dd111ee2222", latest_change: "2014-01-01T00:00:00Z", true_targets: ["SearchWorksPreview"], collections: ["druid:oo000oo0001"] },
         { druid: "druid:bb111cc2222", latest_change: "2015-01-01T00:00:00Z", true_targets: ["SearchWorks", "Revs", "SearchWorksPreview"], collections: ["druid:oo000oo0001", "druid:oo000oo0002"] },
-        { druid: "druid:aa111bb2222",  latest_change: "2016-06-06T00:00:00Z", true_targets: ["SearchWorksPreview"] } # note no collections
+        { druid: "druid:aa111bb2222", latest_change: "2016-06-06T00:00:00Z", true_targets: ["SearchWorksPreview"] } # note no collections
       ],
       pages: pagination_response
     }

--- a/spec/features/purl_finder_spec.rb
+++ b/spec/features/purl_finder_spec.rb
@@ -178,7 +178,7 @@ describe PurlFinder do
         FileUtils.cp_r test_purl_source_dir, test_purl_dest_dir
 
         # # We now have a new file
-        finder_file_test(mins_ago: nil, expected_num_files_found: n+1)
+        finder_file_test(mins_ago: nil, expected_num_files_found: n + 1)
 
         # Clear the temp file and purl back out
         delete_file(empty_file)

--- a/spec/features/purl_listener_spec.rb
+++ b/spec/features/purl_listener_spec.rb
@@ -32,6 +32,7 @@ describe PurlListener do
     end
 
     it 'runs delta rake if listener was previously active' do
+      expect(subject.logger).to receive(:info).with(/no PID file/)
       expect(subject.logger).to receive(:info).with(/Starting/)
 
       # check that we are running for the nth time
@@ -58,10 +59,12 @@ describe PurlListener do
     end
 
     it 'does nothing if the listener is not running' do
+      expect(subject.logger).to receive(:info).with(/no PID file/)
       expect(subject).to receive(:'running?').and_return(false)
       subject.stop
     end
     it 'sends signal if the listener is running' do
+      expect(subject.logger).to receive(:info).with(/no PID file/)
       expect(subject).to receive(:'running?').and_return(true)
       expect(subject).to receive(:pid).and_return(123)
       expect(Process).to receive(:kill).with(/TERM/, 123)
@@ -75,6 +78,7 @@ describe PurlListener do
       subject.stop
     end
     it 'cleans up orphaned pid_file' do
+      expect(subject.logger).to receive(:info).with(/no PID file/)
       expect(subject).to receive(:'running?').and_return(false)
       expect(subject.pid_file).to receive(:delete).and_raise(Errno::ENOENT)
       subject.stop


### PR DESCRIPTION
…ave two different build rake tasks; fix all existing rubocop issues (which means slightly increasing default ABC complexity to allow for one method to exist unchanged)

fixes #163 