### PR TITLE
Add membership param

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The `/purls` endpoint provides information about public PURL documents.
 Name | Located In | Description | Required | Schema | Default
 ---- | ---------- | ----------- | -------- | ------ | -------
 `object_type` | query | limit requests to a specific `object_type` | No | string | null
-`membership` | query | limit requests by membership type, for instance items with no membership (collection) | No | string accepted values: `none` | null
+`membership` | query | limit requests by membership type, for instance items with no membership (collection) | No | string accepted values: `none`, `collection` | null
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
 `version` | header | Version of the API request eg(`version=1`) | No | integer | 1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The `/purls` endpoint provides information about public PURL documents.
 Name | Located In | Description | Required | Schema | Default
 ---- | ---------- | ----------- | -------- | ------ | -------
 `object_type` | query | limit requests to a specific `object_type` | No | string | null
+`membership` | query | limit requests by membership type, for instance items with no membership (collection) | No | string accepted values: `none` | null
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
 `version` | header | Version of the API request eg(`version=1`) | No | integer | 1

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -6,6 +6,7 @@ module V1
       @purls = Purl.all
                    .includes(:collections, :release_tags)
                    .filter(filter_params)
+                   .membership(membership_param)
                    .page(page_params[:page])
                    .per(per_page_params[:per_page])
     end
@@ -24,6 +25,10 @@ module V1
 
       def object_type_param
         params.permit(:object_type)
+      end
+
+      def membership_param
+        params.permit(:membership)
       end
   end
 end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -10,6 +10,13 @@ class Purl < ActiveRecord::Base
 
   scope :object_type, -> (object_type) { where object_type: object_type }
 
+  scope :membership, lambda { |membership|
+    case membership['membership']
+    when 'none'
+      includes(:collections).where(collections: { id: nil })
+    end
+  }
+
   # class level method to create or update a purl model object given a path to a purl directory
   # @param [String] `path` path to a PURL directory
   # @return [Boolean] success or failure

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -12,6 +12,8 @@ class Purl < ActiveRecord::Base
 
   scope :membership, lambda { |membership|
     case membership['membership']
+    when 'collection'
+      joins(:collections)
     when 'none'
       includes(:collections).where(collections: { id: nil })
     end

--- a/spec/controllers/v1/purls_controller_spec.rb
+++ b/spec/controllers/v1/purls_controller_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe V1::PurlsController do
         expect(assigns(:purls).count).to eq 1
       end
     end
+    describe 'uses membership scope' do
+      it 'to limit non-member objects' do
+        get :index, format: :json, membership: 'none'
+        expect(assigns(:purls).count).to eq 4
+      end
+    end
     describe 'pagination parameters' do
       it 'per_page' do
         get :index, format: :json, per_page: 1

--- a/spec/controllers/v1/purls_controller_spec.rb
+++ b/spec/controllers/v1/purls_controller_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe V1::PurlsController do
         get :index, format: :json, membership: 'none'
         expect(assigns(:purls).count).to eq 4
       end
+      it 'to limit only objects that are part of a collection' do
+        get :index, format: :json, membership: 'collection'
+        expect(assigns(:purls).count).to eq 4
+      end
     end
     describe 'pagination parameters' do
       it 'per_page' do

--- a/spec/features/docs_controller_spec.rb
+++ b/spec/features/docs_controller_spec.rb
@@ -22,7 +22,8 @@ describe(V1::DocsController, type: :request, integration: true) do
         { druid: "druid:dd111ee2222", latest_change: "2014-01-01T00:00:00Z", true_targets: ["SearchWorksPreview"], collections: ["druid:ff111gg2222"] },
         { druid: "druid:bb111cc2222", latest_change: "2015-01-01T00:00:00Z", true_targets: ["SearchWorks", "Revs", "SearchWorksPreview"], collections: ["druid:ff111gg2222"] },
         { druid: "druid:aa111bb2222", latest_change: "2016-06-06T00:00:00Z", true_targets: ["SearchWorksPreview"], collections: ["druid:gg111hh2222"] },
-        { druid: "druid:gg111hh2222", latest_change: "2016-06-08T00:00:00Z", true_targets: ["SearchWorksPreview"] }
+        { druid: "druid:gg111hh2222", latest_change: "2016-06-08T00:00:00Z", true_targets: ["SearchWorksPreview"] },
+        { druid: "druid:hh111ii2222", latest_change: "2016-06-09T00:00:00Z", true_targets: ["SearchWorksPreview"] }
       ],
       pages: pagination_response
     }

--- a/spec/features/purl_finder_spec.rb
+++ b/spec/features/purl_finder_spec.rb
@@ -213,7 +213,7 @@ describe PurlFinder do
         expect(index_counts[:error]).to eq(0)
         # Confirm results against the database
         expect(Purl.all.count).to eq(num_purl_fixtures_in_database + n) # two extra items indexed
-        indexed_druids = ["druid:bb050dj7711", "druid:ct961sj2730", "druid:nc687px4289", 'druid:gg111hh2222']
+        indexed_druids = ["druid:bb050dj7711", "druid:ct961sj2730", "druid:nc687px4289", 'druid:gg111hh2222', 'druid:hh111ii2222']
         all_druids = indexed_druids + fixture_druids_in_database
         expect(Purl.all.map(&:druid).sort).to eq(all_druids.sort) # sort so we do not have to worry about ordering, just if they match the expected druids
         expect(RunLog.count).to eq(1)

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -7,14 +7,23 @@ describe Purl, type: :model do
       it 'returns objects that do not belong to a collection' do
         objects = described_class.membership('membership' => 'none')
         expect(objects.count).to eq 4
-        described_class.membership('membership' => 'none').each do |purl|
+        objects.each do |purl|
           expect(purl.collections).to be_empty
+        end
+      end
+    end
+    context 'when passed "collection"' do
+      it 'returns objects that only belong to a collection' do
+        objects = described_class.membership('membership' => 'collection')
+        expect(objects.count).to eq 4
+        objects.each do |purl|
+          expect(purl.collections.count).to eq 1
         end
       end
     end
     context 'anything else' do
       it 'returns everything' do
-        expect(described_class.membership('').count).to eq Purl.all.count
+        expect(described_class.membership('yolo').count).to eq described_class.all.count
       end
     end
   end

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -2,6 +2,22 @@ require 'rails_helper'
 
 describe Purl, type: :model do
   let(:druid) { 'druid:bb050dj7711' }
+  describe '.membership' do
+    context 'when passed "none"' do
+      it 'returns objects that do not belong to a collection' do
+        objects = described_class.membership('membership' => 'none')
+        expect(objects.count).to eq 4
+        described_class.membership('membership' => 'none').each do |purl|
+          expect(purl.collections).to be_empty
+        end
+      end
+    end
+    context 'anything else' do
+      it 'returns everything' do
+        expect(described_class.membership('').count).to eq Purl.all.count
+      end
+    end
+  end
   describe '.mark_deleted' do
     it 'always starts without deleted_at time' do
       purl = described_class.create(druid: druid)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ def finder_file_test(params={})
 end
 
 def num_purl_fixtures_in_database
-  7 # Purl.all.count # this is useful to know for testing expectations that will increase this number during the test
+  8 # Purl.all.count # this is useful to know for testing expectations that will increase this number during the test
 end
 
 def fixture_druids_in_database

--- a/test/fixtures/purls.yml
+++ b/test/fixtures/purls.yml
@@ -53,3 +53,9 @@ indexed_7:
   druid: druid:gg111hh2222
   object_type: 'collection|set'
   published_at: <%=Time.zone.parse('8/6/2016').iso8601%>
+indexed_8:
+  id: 8
+  druid: druid:hh111ii2222
+  object_type: item
+  published_at: <%=Time.zone.parse('9/6/2016').iso8601%>
+  title: An object not in a collection


### PR DESCRIPTION
Closes #167 

An example request to get all object type=items that are not in a collection:

`/purls?object_type=items&membership=none`

