### PR TITLE
Adds filters/scopes for deleted/public purls and targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Name | Located In | Description | Required | Schema | Default
 ---- | ---------- | ----------- | -------- | ------ | -------
 `object_type` | query | limit requests to a specific `object_type` | No | string | null
 `membership` | query | limit requests by membership type, for instance items with no membership (collection) | No | string accepted values: `none`, `collection` | null
+`status` | query | limit requests by status of object (`deleted`, `public`) | No | string
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
 `version` | header | Version of the API request eg(`version=1`) | No | integer | 1

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Name | Located In | Description | Required | Schema | Default
 ---- | ---------- | ----------- | -------- | ------ | -------
 `object_type` | query | limit requests to a specific `object_type` | No | string | null
 `membership` | query | limit requests by membership type, for instance items with no membership (collection) | No | string accepted values: `none`, `collection` | null
-`status` | query | limit requests by status of object (`deleted`, `public`) | No | string
+`status` | query | limit requests by status of object (`deleted`, `public`) | No | string | null
+`target` | query | limit requests by release tag targets (`SearchWorks`, `Revs`) case sensitive | No | string | null
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
 `version` | header | Version of the API request eg(`version=1`) | No | integer | 1

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -6,6 +6,7 @@ module V1
       @purls = Purl.all
                    .includes(:collections, :release_tags)
                    .filter(filter_params)
+                   .status(status_param)
                    .membership(membership_param)
                    .page(page_params[:page])
                    .per(per_page_params[:per_page])
@@ -38,6 +39,10 @@ module V1
 
       def membership_param
         params.permit(:membership)
+      end
+
+      def status_param
+        params.permit(:status)
       end
   end
 end

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -7,6 +7,7 @@ module V1
                    .includes(:collections, :release_tags)
                    .filter(filter_params)
                    .status(status_param)
+                   .target(target_param)
                    .membership(membership_param)
                    .page(page_params[:page])
                    .per(per_page_params[:per_page])
@@ -43,6 +44,10 @@ module V1
 
       def status_param
         params.permit(:status)
+      end
+
+      def target_param
+        params.permit(:target)
       end
   end
 end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -19,6 +19,15 @@ class Purl < ActiveRecord::Base
     end
   }
 
+  scope :status, lambda { |status|
+    case status['status']
+    when 'deleted'
+      where.not deleted_at: nil
+    when 'public'
+      where deleted_at: nil
+    end
+  }
+
   ##
   # Return true targets with always values only if the object is not deleted in
   # purl mount

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -28,6 +28,11 @@ class Purl < ActiveRecord::Base
     end
   }
 
+  scope :target, lambda { |target|
+    return unless target['target'].present?
+    includes(:release_tags).where(release_tags: { name: target['target'] })
+  }
+
   ##
   # Return true targets with always values only if the object is not deleted in
   # purl mount

--- a/spec/controllers/v1/purls_controller_spec.rb
+++ b/spec/controllers/v1/purls_controller_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe V1::PurlsController do
         expect(assigns(:purls).count).to eq 5
       end
     end
+    describe 'uses target scope' do
+      it 'to limit targets objects' do
+        get :index, format: :json, target: 'SearchWorks'
+        expect(assigns(:purls).count).to eq 2
+      end
+    end
     describe 'pagination parameters' do
       it 'per_page' do
         get :index, format: :json, per_page: 1

--- a/spec/controllers/v1/purls_controller_spec.rb
+++ b/spec/controllers/v1/purls_controller_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe V1::PurlsController do
         expect(assigns(:purls).count).to eq 4
       end
     end
+    describe 'uses status scope' do
+      it 'to limit deleted objects' do
+        get :index, format: :json, status: 'deleted'
+        expect(assigns(:purls).count).to eq 3
+      end
+      it 'to limit only objects that are public' do
+        get :index, format: :json, status: 'public'
+        expect(assigns(:purls).count).to eq 5
+      end
+    end
     describe 'pagination parameters' do
       it 'per_page' do
         get :index, format: :json, per_page: 1

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -85,6 +85,25 @@ describe Purl, type: :model do
       end
     end
   end
+  describe '.target' do
+    context 'when passed a valid target' do
+      it 'returns objects that have that target' do
+        objects = described_class.target('target' => 'SearchWorks')
+        expect(objects.count).to eq 2
+      end
+    end
+    context 'when passed an invalid target' do
+      it 'returns nothing' do
+        objects = described_class.target('target' => 'SuperCoolStuff')
+        expect(objects.count).to eq 0
+      end
+    end
+    context 'anything else' do
+      it 'returns everything' do
+        expect(described_class.target('yolo').count).to eq described_class.all.count
+      end
+    end
+  end
   describe '.mark_deleted' do
     it 'always starts without deleted_at time' do
       purl = described_class.create(druid: druid)

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -66,6 +66,25 @@ describe Purl, type: :model do
       end
     end
   end
+  describe '.status' do
+    context 'when passed "deleted"' do
+      it 'returns objects that have been deleted' do
+        objects = described_class.status('status' => 'deleted')
+        expect(objects.count).to eq 3
+      end
+    end
+    context 'when passed "collection"' do
+      it 'returns objects that are still public' do
+        objects = described_class.status('status' => 'public')
+        expect(objects.count).to eq 5
+      end
+    end
+    context 'anything else' do
+      it 'returns everything' do
+        expect(described_class.status('yolo').count).to eq described_class.all.count
+      end
+    end
+  end
   describe '.mark_deleted' do
     it 'always starts without deleted_at time' do
       purl = described_class.create(druid: druid)


### PR DESCRIPTION
In discussing with @lmcglohon it seemed like it would be useful to add some more parameters to the Purl api. These are additive and non-breaking.