### PR TITLE
retrieve publication time from public XML not file mtime

### DIFF
--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -85,7 +85,7 @@ class Purl < ActiveRecord::Base
       end
     end
 
-    self.published_at = public_xml.modified_time
+    self.published_at = public_xml.published_at
     self.deleted_at = nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
 
     save

--- a/lib/purl_parser.rb
+++ b/lib/purl_parser.rb
@@ -77,9 +77,9 @@ class PurlParser
   end
 
   ##
-  # Returns the file modified time, in local zone.
+  # Returns the publication time, in local time zone.
   # @return [Time]
-  def modified_time
-    @public_path.mtime
+  def published_at
+    @published_at ||= Time.parse(public_xml.at_xpath('//publicObject').attr('published').to_s).in_time_zone
   end
 end

--- a/spec/features/purl_parser_spec.rb
+++ b/spec/features/purl_parser_spec.rb
@@ -51,16 +51,16 @@ describe PurlParser do
       expect(purl.exists?).to be_falsey
     end
   end
-  describe '#modified_time' do
+  describe '#published_at' do
     let(:sample_doc_path) do
       DruidTools::PurlDruid.new('bb050dj7711', purl_fixture_path).path
     end
     subject { described_class.new(sample_doc_path) }
-    it 'gets the file modified_time from file system' do
-      before_modified = Time.zone.now - 1.second
-      FileUtils.touch(Pathname(sample_doc_path) + 'public')
-      expect(subject.modified_time).to be > before_modified
-      expect(subject.modified_time).to be_an Time
+    it 'gets the published_at metadata directly from the public XML' do
+      expect(subject.published_at).to be_an Time
+      expect(subject.published_at.zone).to eq('UTC') # this is the local timezone for our Rails instances
+      # the metadata is actually in a non-UTC zone so we ensure it gets converted to the local timezone (UTC)
+      expect(subject.published_at.iso8601).to eq('2015-04-09T20:20:16Z')
     end
   end
 

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -34,7 +34,7 @@ describe Purl, type: :model do
       expect(purl_object.title).to eq 'This is Pete\'s New Test title for this object.'
       expect(purl_object.release_tags.count).to eq 3
       expect(purl_object.collections.count).to eq 2
-      expect(purl_object.published_at).not_to be_nil
+      expect(purl_object.published_at.iso8601).to eq '2015-04-09T20:20:16Z' # should be in UTC
       expect(purl_object.deleted_at).to be_nil
     end
     context 'public xml unavailable' do


### PR DESCRIPTION
This PR fixes #181 by retrieving the publication time from a more authorative source from within the public XML rather than relying on the timestamp of the `public` file.