### PR TITLE
remove references to indexing and replace with update and save

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # purl-fetcher
 
-A web service app that queries PURL to return info needed for indexing or other purposes.
+A web service app that queries PURL to return info needed for updating a database that can be queried via REST APIs.
 
 ## Setting up your environment
 
@@ -30,7 +30,7 @@ rails server
 
 There are three log files:
 
-* `indexing.log` - items that are being indexed (added or deleted)
+* `indexing.log` - items that are being saved (added or deleted)
 * `[environment].log` - Rails logger
 * `access.log` and `error.log` from Apache - traffic to the HTTP APIs
 

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -1,5 +1,5 @@
 defaults: &defaults
-  filename_indexing_log: "log/indexing.log"
+  filename_updating_log: "log/indexing.log"
   purl_document_path: "/purl/document_cache"
   deletes_dir: ".deletes"
   listener_path: "/purl/recent_changes"

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,6 @@ module PurlFetcher
   end
 end
 
-IndexingLogger = Logger.new(PurlFetcher::Application.config.app_config['filename_indexing_log'])
-IndexingLogger.level = Logger::INFO
+UpdatingLogger = Logger.new(PurlFetcher::Application.config.app_config['filename_updating_log'])
+UpdatingLogger.level = Logger::INFO
 

--- a/lib/purl_listener.rb
+++ b/lib/purl_listener.rb
@@ -31,7 +31,7 @@ class PurlListener
   # @raise [ArgumentError] -- requires path to be a directory
   def initialize(path = Pathname(PurlFetcher::Application.config.app_config['listener_path']),
                  pid_file = Pathname(PurlFetcher::Application.config.app_config['listener_pid_file']),
-                 logger = IndexingLogger)
+                 logger = UpdatingLogger)
     raise ArgumentError, "Missing #{path}" unless path.directory?
     @pid_file = pid_file
     @pid = nil

--- a/lib/purl_parser.rb
+++ b/lib/purl_parser.rb
@@ -13,7 +13,7 @@ class PurlParser
       @public_xml ||= Nokogiri::XML(@public_path.open)
     rescue => e
       Honeybadger.notify(e)
-      IndexingLogger.error("For #{path} could not read public XML.  #{e.message}")
+      UpdatingLogger.error("For #{path} could not read public XML.  #{e.message}")
     end
   end
 

--- a/lib/tasks/find.rake
+++ b/lib/tasks/find.rake
@@ -13,9 +13,9 @@ namespace :find do
   task :changes, [:mins_ago] => :environment do |_t, args|
     args.with_defaults(mins_ago: nil)
     elapsed_time = Benchmark.realtime do
-      PurlFinder.new.find_and_index(mins_ago: args[:mins_ago])
+      PurlFinder.new.find_and_save(mins_ago: args[:mins_ago])
     end
-    IndexingLogger.info("Ran 'find:changes[#{args[:mins_ago]}]' in #{elapsed_time.ceil} seconds")
+    UpdatingLogger.info("Ran 'find:changes[#{args[:mins_ago]}]' in #{elapsed_time.ceil} seconds")
   end
 
   desc 'Scan filesystem PURL objects deletes - optionally, only last n minutes.'
@@ -24,6 +24,6 @@ namespace :find do
     elapsed_time = Benchmark.realtime do
       PurlFinder.new.remove_deleted(mins_ago: args[:mins_ago])
     end
-    IndexingLogger.info("Ran 'find:deletes[#{args[:mins_ago]}]' in #{elapsed_time.ceil} seconds")
+    UpdatingLogger.info("Ran 'find:deletes[#{args[:mins_ago]}]' in #{elapsed_time.ceil} seconds")
   end
 end

--- a/spec/features/purl_listener_spec.rb
+++ b/spec/features/purl_listener_spec.rb
@@ -9,7 +9,7 @@ describe PurlListener do
       expect(subject.pid_file).to eq Pathname(PurlFetcher::Application.config.app_config['listener_pid_file'])
     end
     it 'using the correct logger' do
-      expect(subject.logger).to eq IndexingLogger
+      expect(subject.logger).to eq UpdatingLogger
     end
     it 'has an event handler' do
       expect(subject.event_handler).to be_an Proc


### PR DESCRIPTION
fixes #161 

renames a whole slew of methods, are they are consumers other than the rake task that need to be aware of this?

left a log file name as "indexing" since i wasn't sure if it was monitored