### PR TITLE
rescue exceptions during listener process check

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -29,10 +29,20 @@ class PidCheck < OkComputer::Check
           else
             @pid
           end
-    if pid.present? && Process.kill(0, pid)
-      mark_message "process #{pid} is running"
+    if pid.present?
+      begin
+        if Process.kill(0, pid)
+          mark_message "process #{pid} is running"
+        else
+          mark_message "process #{pid} is not responding"
+          mark_failure
+        end
+      rescue Errno::ESRCH, Errno::EPERM
+        mark_message "process #{pid} is not running properly"
+        mark_failure
+      end
     else
-      mark_message "process #{pid} is not running"
+      mark_message "no listener process to check?"
       mark_failure
     end
   end


### PR DESCRIPTION
Currently, if the listener process is registered but doesn't exist, the monitoring endpoint will raise an exception rather than cleanly mark a monitoring failure.

`Errno::ESRCH: No such process`

so this PR rescues the exceptions and marks a monitoring failure rather than send to Honeybadger and a 500 status code.

See https://app.honeybadger.io/projects/48916/faults/31575847

@eefahy 
