### PR TITLE
add listener:recent_changes:process task to restart procedure

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,3 +5,8 @@ set :output, '/dev/null'
 every 15.minutes do
  rake 'find:deletes[15]' # scan .deletes directory for new deletes
 end
+
+# ensures that all changes touch files are processed if the listener was down
+every 1.hour do
+  rake 'listener:recent_changes:process'
+end

--- a/lib/tasks/listener.rake
+++ b/lib/tasks/listener.rake
@@ -36,4 +36,16 @@ namespace :listener do
 
   desc 'Restart the listener'
   task :restart => [:stop, :start]
+
+  namespace :recent_changes do
+    desc 'Process all recent_changes touch files. Requires Listener to be running.'
+    task :process => :environment do
+      listener = PurlListener.new
+      if listener.running?
+        system("find #{listener.path} -type f | xargs touch")
+      else
+        puts "Listener is not running"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #185. We touch all the files in `/purl/recent_changes` every hour when the listener is running. This ensures we process them all in case the listener was down or restarted.