### PR TITLE
update the purl fetcher changes api to use the updated_at column inst…

### DIFF
--- a/app/controllers/v1/docs_controller.rb
+++ b/app/controllers/v1/docs_controller.rb
@@ -5,7 +5,7 @@ module V1
     # API call to get a full list of all purls modified between two times
     def changes
       @changes = Purl.where(deleted_at: nil)
-                     .where(published_at: @first_modified..@last_modified)
+                     .where(updated_at: @first_modified..@last_modified)
                      .includes(:collections, :release_tags)
                      .page(page_params[:page])
                      .per(per_page_params[:per_page])

--- a/db/migrate/20170321232801_add_updated_at_index_to_purl.rb
+++ b/db/migrate/20170321232801_add_updated_at_index_to_purl.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAtIndexToPurl < ActiveRecord::Migration
+  def change
+    add_index :purls, :updated_at
+  end
+end

--- a/spec/features/docs_controller_spec.rb
+++ b/spec/features/docs_controller_spec.rb
@@ -30,6 +30,7 @@ describe(V1::DocsController, type: :request, integration: true) do
     expect(results).to eq(expected_results.with_indifferent_access)
   end
   it "test the docs changes API call for a specified time period" do
+    Purl.find_by_druid('druid:dd111ee2222').update_column(:updated_at, Time.zone.parse('2014/01/01').iso8601)
     get changes_docs_path(first_modified: Time.zone.parse('2013/12/31').iso8601, last_modified: Time.zone.parse('2014/01/02').iso8601)
     expect(response).to be_success
     results = JSON.parse(response.body)


### PR DESCRIPTION
…ead of the published_at column when returning changes to avoid any gap issues for items published when purl-fetcher listener was down/hung