### PR TITLE
Allow doc changes and deletes to be filtered on their release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Name | Located In | Description | Required | Schema | Default
 `last_modified` | query | Limit response by an ending datetime| No | datetime in iso8601 | current time
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
+`target` | query | Release tag to filter on | No | string | nil
 `version` | header | Version of the API request eg(`version=1`) | No | integer | 1
 
 ##### Example Response
@@ -240,6 +241,7 @@ Name | Located In | Description | Required | Schema | Default
 `last_modified` | query | Limit response by an ending datetime| No | datetime in iso8601 | current time
 `page` | query | request a specific page of results | No | integer | 1
 `per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
+`target` | query | Release tag to filter on | No | string | nil
 `version` | header | Version of the API request eg(`version=1`) | No | integer | 1
 
 ##### Example Response

--- a/app/controllers/v1/docs_controller.rb
+++ b/app/controllers/v1/docs_controller.rb
@@ -6,6 +6,7 @@ module V1
     def changes
       @changes = Purl.where(deleted_at: nil)
                      .where(updated_at: @first_modified..@last_modified)
+                     .target('target' => params[:target])
                      .includes(:collections, :release_tags)
                      .page(page_params[:page])
                      .per(per_page_params[:per_page])
@@ -14,6 +15,7 @@ module V1
     # API call to get a full list of all purl deletes between two times
     def deletes
       @deletes = Purl.where(deleted_at: @first_modified..@last_modified)
+                     .target('target' => params[:target])
                      .reorder(:deleted_at) # used to override the default_scope
                      .page(page_params[:page])
                      .per(per_page_params[:per_page])

--- a/spec/controllers/v1/docs_controller_spec.rb
+++ b/spec/controllers/v1/docs_controller_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe V1::DocsController do
         expect(assigns(:changes).count).to eq 1
       end
     end
+
+    it 'is filterable by target' do
+      get :changes, params: { target: 'SearchWorks' }, format: :json
+      expect(assigns(:changes).map(&:druid)).to match_array ['druid:bb111cc2222']
+    end
   end
 
   describe '#deletes' do
@@ -44,6 +49,11 @@ RSpec.describe V1::DocsController do
           expect(assigns(:deletes).count).to eq 1
         end
       end
+    end
+
+    it 'is filterable by target' do
+      get :deletes, params: { target: 'SearchWorks' }, format: :json
+      expect(assigns(:deletes).map(&:druid)).to match_array ['druid:cc111dd2222']
     end
   end
 end


### PR DESCRIPTION
This should let us write indexing clients that go directly to purl fetcher to retrieve data, instead of waiting for discovery-dispatcher to push changes. 