### PR TITLE
Include the catkey information in the doc changes responses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - 'spec/rails_helper.rb'
     - 'vendor/**/*'
     - 'tmp/**/*'
-  
+
 Rails:
   Enabled: true
 
@@ -28,6 +28,9 @@ Layout/EmptyLineBetweenDefs:
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
   Max: 200
+  Exclude:
+    - 'spec/features/docs_controller_spec.rb'
+
 Metrics/AbcSize:
   Max: 30
 

--- a/app/views/v1/docs/changes.json.jbuilder
+++ b/app/views/v1/docs/changes.json.jbuilder
@@ -1,6 +1,7 @@
 json.changes @changes do |change|
   json.druid change.druid
   json.latest_change change.published_at.iso8601
+  json.catkey change.catkey if change.catkey.present?
   json.partial! 'shared/true_targets', locals: { true_targets: change.true_targets }
   json.false_targets change.false_targets if change.false_targets.present?
   json.collections change.collections.map(&:druid) if change.collections.present?

--- a/spec/features/docs_controller_spec.rb
+++ b/spec/features/docs_controller_spec.rb
@@ -21,7 +21,7 @@ describe(V1::DocsController, type: :request, integration: true) do
     expected_results = { changes:
       [
         { druid: "druid:dd111ee2222", latest_change: "2014-01-01T00:00:00Z", true_targets: ["SearchWorksPreview", "ContentSearch"], collections: ["druid:ff111gg2222"] },
-        { druid: "druid:bb111cc2222", latest_change: "2015-01-01T00:00:00Z", true_targets: ["SearchWorks", "Revs", "SearchWorksPreview", "ContentSearch"], collections: ["druid:ff111gg2222"] },
+        { druid: "druid:bb111cc2222", catkey: 'catkey111', latest_change: "2015-01-01T00:00:00Z", true_targets: ["SearchWorks", "Revs", "SearchWorksPreview", "ContentSearch"], collections: ["druid:ff111gg2222"] },
         { druid: "druid:aa111bb2222", latest_change: "2016-06-06T00:00:00Z", true_targets: ["SearchWorksPreview", "ContentSearch"], collections: ["druid:gg111hh2222"] },
         { druid: "druid:gg111hh2222", latest_change: "2016-06-08T00:00:00Z", true_targets: ["SearchWorksPreview", "ContentSearch"] },
         { druid: "druid:hh111ii2222", latest_change: "2016-06-09T00:00:00Z", true_targets: ["SearchWorksPreview", "ContentSearch"] }

--- a/spec/views/v1/purls/_purl.json.jbuilder_spec.rb
+++ b/spec/views/v1/purls/_purl.json.jbuilder_spec.rb
@@ -7,7 +7,7 @@ describe 'v1/purls/_purl.json.jbuilder' do
       'collections' => ['druid:ff111gg2222'],
       'druid' => 'druid:bb111cc2222',
       'object_type' => 'item',
-      'catkey' => '',
+      'catkey' => 'catkey111',
       'title' => 'Some test object'
     )
   end

--- a/test/fixtures/purls.yml
+++ b/test/fixtures/purls.yml
@@ -9,7 +9,7 @@ indexed_1:
   druid: druid:bb111cc2222
   title: Some test object
   object_type: item
-  catkey: ''
+  catkey: 'catkey111'
   published_at: <%=Time.zone.parse('1/1/2015').iso8601%>
 indexed_2:
   id: 2


### PR DESCRIPTION
This will save the searchworks indexer a request to purl for the public xml when trying to determine if a released object should be etracted after a catkey is added