### PR TITLE
Store the public xml in the purl-fetcher database

### DIFF
--- a/app/models/public_xml.rb
+++ b/app/models/public_xml.rb
@@ -1,0 +1,11 @@
+class PublicXml < ApplicationRecord
+  belongs_to :purl
+
+  def data=(data)
+    super(ActiveSupport::Gzip.compress(data))
+  end
+
+  def data
+    ActiveSupport::Gzip.decompress(super)
+  end
+end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -76,7 +76,7 @@ class Purl < ApplicationRecord
   ##
   # Updates a Purl using information from the public xml document
   def update_from_public_xml!
-    public_xml = PurlParser.new(path)
+    public_xml = PurlParser.new(druid)
 
     return false unless public_xml.exists?
 
@@ -121,16 +121,4 @@ class Purl < ApplicationRecord
     purl.collections.delete_all
     purl.save
   end
-
-  private
-
-    ##
-    # Path to the location of public xml document
-    # @return [String]
-    def path
-      DruidTools::PurlDruid.new(
-        druid,
-        Settings.PURL_DOCUMENT_PATH
-      ).path
-    end
 end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -1,6 +1,9 @@
 class Purl < ApplicationRecord
   has_and_belongs_to_many :collections
   has_many :release_tags, dependent: :destroy
+  has_one :public_xml, dependent: :destroy
+
+  accepts_nested_attributes_for :public_xml, update_only: true
   paginates_per 100
   max_paginates_per 10_000
   default_scope -> { order(:updated_at) }
@@ -94,7 +97,8 @@ class Purl < ApplicationRecord
       object_type: public_xml.object_type,
       catkey: public_xml.catkey,
       published_at: public_xml.published_at,
-      deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
+      deleted_at: nil, # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
+      public_xml_attributes: { data: public_xml.public_xml.to_s }
     )
 
     ##

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -103,18 +103,6 @@ class Purl < ApplicationRecord
     save!
   end
 
-  # class level method to create or update a purl model object given a path to a purl directory
-  # @param [String] `path` path to a PURL directory
-  # @return [Boolean] success or failure
-  def self.save_from_public_xml(path)
-    public_xml = PurlParser.new(path)
-
-    return false unless public_xml.exists?
-
-    purl = find_or_initialize_by(druid: public_xml.druid) # either create a new druid record or get the existing one
-    purl.update_from_public_xml!
-  end
-
   ##
   # Specify an instance's `deleted_at` attribute which denotes when an object's
   # public xml is gone

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -80,7 +80,7 @@ class Purl < ApplicationRecord
 
     return false unless public_xml.exists?
 
-    self.druid = public_xml.druid
+    self.druid = public_xml.canonical_druid
     self.title = public_xml.title
     self.object_type = public_xml.object_type
     self.catkey = public_xml.catkey

--- a/db/migrate/20211108224213_create_public_xmls.rb
+++ b/db/migrate/20211108224213_create_public_xmls.rb
@@ -1,0 +1,10 @@
+class CreatePublicXmls < ActiveRecord::Migration[6.1]
+  def change
+    create_table :public_xmls do |t|
+      t.references :purl
+      t.binary :data, limit: 16777216
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_200244) do
+ActiveRecord::Schema.define(version: 2021_11_08_224213) do
 
   create_table "collections", force: :cascade do |t|
     t.string "druid", null: false
@@ -35,6 +35,14 @@ ActiveRecord::Schema.define(version: 2020_03_19_200244) do
     t.datetime "updated_at", null: false
     t.index ["process_id"], name: "index_listener_logs_on_process_id"
     t.index ["started_at"], name: "index_listener_logs_on_started_at"
+  end
+
+  create_table "public_xmls", force: :cascade do |t|
+    t.integer "purl_id"
+    t.binary "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["purl_id"], name: "index_public_xmls_on_purl_id"
   end
 
   create_table "purls", force: :cascade do |t|

--- a/lib/purl_parser.rb
+++ b/lib/purl_parser.rb
@@ -11,6 +11,7 @@ class PurlParser
   rescue => e
     Honeybadger.notify(e)
     UpdatingLogger.error("For #{path} could not read public XML.  #{e.message}")
+    nil
   end
 
   def exists?

--- a/lib/purl_parser.rb
+++ b/lib/purl_parser.rb
@@ -40,7 +40,7 @@ class PurlParser
   #
   # @return [String] The druid in the form of druid:pid
   #
-  def druid
+  def canonical_druid
     public_xml.at_xpath('//publicObject').attr('id')
   end
 

--- a/spec/features/purl_parser_spec.rb
+++ b/spec/features/purl_parser_spec.rb
@@ -10,7 +10,7 @@ describe PurlParser do
     end
 
     it 'gets the druid from publicMetadata' do
-      expect(purl.druid).to match('druid:bb050dj7711')
+      expect(purl.canonical_druid).to match('druid:bb050dj7711')
     end
 
     it 'gets true and false data from the public xml regarding release status' do

--- a/spec/features/purl_parser_spec.rb
+++ b/spec/features/purl_parser_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 describe PurlParser do
   describe('bb050dj7711') do
-    let(:sample_doc_path) { DruidTools::PurlDruid.new('bb050dj7711', purl_fixture_path).path }
-    let(:purl) { described_class.new(sample_doc_path) }
+    let(:purl) { described_class.new('bb050dj7711') }
 
     it 'gets the title from the mods file' do
       expect(purl.title).to eq("This is Pete's New Test title for this object.")
@@ -31,8 +30,7 @@ describe PurlParser do
   end
 
   describe('ct961sj2730') do
-    let(:sample_doc_path) { DruidTools::PurlDruid.new('ct961sj2730', purl_fixture_path).path }
-    let(:purl) { described_class.new(sample_doc_path) }
+    let(:purl) { described_class.new('ct961sj2730') }
 
     it 'gets the cat key when one is present' do
       expect(purl.catkey).to match('10357851')
@@ -44,8 +42,7 @@ describe PurlParser do
   end
 
   describe('bb050dj0000') do
-    let(:sample_doc_path) { DruidTools::PurlDruid.new('bb050dj0000', purl_fixture_path).path }
-    let(:purl) { described_class.new(sample_doc_path) }
+    let(:purl) { described_class.new('bb050dj0000') }
 
     it 'does not find the public xml' do
       expect(purl.exists?).to be_falsey
@@ -53,11 +50,8 @@ describe PurlParser do
   end
 
   describe '#published_at' do
-    let(:sample_doc_path) do
-      DruidTools::PurlDruid.new('bb050dj7711', purl_fixture_path).path
-    end
+    subject { described_class.new('bb050dj7711') }
 
-    subject { described_class.new(sample_doc_path) }
     it 'gets the published_at metadata directly from the public XML' do
       expect(subject.published_at).to be_an Time
       expect(subject.published_at.zone).to eq('UTC') # this is the local timezone for our Rails instances
@@ -67,8 +61,7 @@ describe PurlParser do
   end
 
   describe('nc687px4289') do
-    let(:sample_doc_path) { DruidTools::PurlDruid.new('nc687px4289', purl_fixture_path).path }
-    let(:purl) { described_class.new(sample_doc_path) }
+    let(:purl) { described_class.new('nc687px4289') }
 
     it 'uses the first title' do
       expect(purl.public_xml.xpath('//*[name()="dc:title"]').size).to eq 2 # multiple titles

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -54,6 +54,17 @@ describe Purl, type: :model do
         expect { purl_object.update_from_public_xml! }.to raise_exception(ActiveRecord::RecordInvalid)
       end
     end
+
+    context 'public xml association' do
+      before do
+        purl_object.update(druid: 'druid:bb050dj7711')
+        purl_object.update_from_public_xml!
+      end
+
+      it 'stores the public xml in the database' do
+        expect(purl_object.public_xml&.data).to be_present.and include '<publicObject id="druid:bb050dj7711"'
+      end
+    end
   end
 
   describe '.membership' do

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -159,18 +159,4 @@ describe Purl, type: :model do
         .to change { purl.collections.count }.from(1).to(0)
     end
   end
-
-  describe '.save_from_public_xml' do
-    let(:purl_path) { DruidTools::PurlDruid.new(druid, purl_fixture_path).path }
-
-    it 'does not create duplication Collection or relationships' do
-      n = 2
-      expect do
-        n.times do
-          described_class.save_from_public_xml(purl_path)
-        end
-      end.to change{ Collection.all.count }.by(n)
-      expect(described_class.find_by_druid(druid).collections.count).to eq n
-    end
-  end
 end


### PR DESCRIPTION
We don't have a good way to efficiently crawl through our published PURLs and search for things like cocina urls (https://github.com/sul-dlss/purl/issues/528). Crawling the `/purl` file system mount point isn't very fast (maybe 12 hours for the corpus?) and isn't easy to filter either. 

What if we store the data in our database and compress it for size efficiency because it isn't used regularly?