### PR TITLE
Refactor the update process

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - 'spec/rails_helper.rb'
     - 'vendor/**/*'
     - 'tmp/**/*'
+  SuggestExtensions: false
 
 Rails:
   Enabled: true
@@ -31,7 +32,7 @@ Layout/EmptyLineBetweenDefs:
 
 # Configuration parameters: AllowURI, URISchemes.
 Layout/LineLength:
-  Max: 200
+  Max: 132
   Exclude:
     - 'spec/features/v1/docs_controller_spec.rb'
 
@@ -43,3 +44,6 @@ Style/StringLiterals:
 
 Style/Documentation:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -128,10 +128,6 @@ RSpec/LetBeforeExamples:
   Exclude:
     - 'spec/models/purl_spec.rb'
 
-# Offense count: 32
-RSpec/MultipleExpectations:
-  Max: 6
-
 # Offense count: 9
 # Configuration parameters: IgnoreSharedExamples.
 RSpec/NamedSubject:

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -27,7 +27,7 @@ module V1
               rescue ActiveRecord::RecordNotUnique
                 retry
               end
-      @purl.update_from_public_xml!
+      PurlXmlUpdater.new(@purl).update
       respond_to do |format|
         format.json { render json: true }
       end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -86,33 +86,6 @@ class Purl < ApplicationRecord
   end
 
   ##
-  # Updates a Purl using information from the public xml document
-  def update_from_public_xml!
-    public_xml = PurlParser.new(druid)
-    return false unless public_xml.exists?
-
-    assign_attributes(
-      druid: public_xml.canonical_druid,
-      title: public_xml.title,
-      object_type: public_xml.object_type,
-      catkey: public_xml.catkey,
-      published_at: public_xml.published_at,
-      deleted_at: nil, # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
-      public_xml_attributes: { data: public_xml.public_xml.to_s }
-    )
-
-    ##
-    # Delete all of the collection assocations, and then add back ones in the
-    # public xml
-    refresh_collections(public_xml.collections)
-
-    # add the release tags, and reuse tags if already associated with this PURL
-    refresh_release_tags(public_xml.releases)
-
-    save!
-  end
-
-  ##
   # Specify an instance's `deleted_at` attribute which denotes when an object's
   # public xml is gone
   # @param [String] druid

--- a/app/services/purl_xml_updater.rb
+++ b/app/services/purl_xml_updater.rb
@@ -1,0 +1,46 @@
+# Updates the Purl database record using information from the public xml
+class PurlXmlUpdater
+  def initialize(active_record)
+    @active_record = active_record
+  end
+
+  attr_reader :active_record
+
+  delegate :collections, :releases, to: :public_xml
+
+  def public_xml
+    @public_xml ||= PurlParser.new(active_record.druid)
+  end
+
+  def preconditions_satisfied?
+    public_xml.exists?
+  end
+
+  def attributes
+    {
+      druid: public_xml.canonical_druid,
+      title: public_xml.title,
+      object_type: public_xml.object_type,
+      catkey: public_xml.catkey,
+      published_at: public_xml.published_at,
+      deleted_at: nil, # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
+      public_xml_attributes: { data: public_xml.public_xml.to_s }
+    }
+  end
+
+  def update
+    return false unless preconditions_satisfied?
+
+    active_record.assign_attributes(attributes)
+
+    ##
+    # Delete all of the collection assocations, and then add back ones in the
+    # public xml
+    active_record.refresh_collections(collections)
+
+    # add the release tags, and reuse tags if already associated with this PURL
+    active_record.refresh_release_tags(releases)
+
+    active_record.save!
+  end
+end

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Purl, type: :model do
+RSpec.describe Purl, type: :model do
   describe '#true_targets' do
     context 'when not deleted' do
       subject { create(:purl) }
@@ -26,44 +26,6 @@ describe Purl, type: :model do
       subject.collections << create_list(:collection, 3)
       expect { subject.refresh_collections(['druid:1', 'druid:2']) }
         .to change { subject.collections.count }.from(3).to(2)
-    end
-  end
-
-  describe '#update_from_public_xml!' do
-    let(:purl_object) { create(:purl) }
-
-    it 'updates an instance from public xml' do
-      purl_object.update(druid: 'druid:bb050dj7711')
-      purl_object.update_from_public_xml!
-      expect(purl_object.druid).to eq 'druid:bb050dj7711'
-      expect(purl_object.title).to eq 'This is Pete\'s New Test title for this object.'
-      expect(purl_object.release_tags.count).to eq 3
-      expect(purl_object.collections.count).to eq 2
-      expect(purl_object.published_at.iso8601).to eq '2015-04-09T20:20:16Z' # should be in UTC
-      expect(purl_object.deleted_at).to be_nil
-    end
-
-    context 'public xml unavailable' do
-      it { expect(purl_object.update_from_public_xml!).to be false }
-    end
-
-    context 'validations' do
-      it 'raises exceptions if the validations fail' do
-        create(:purl, druid: 'druid:bb050dj7711')
-        purl_object.update(druid: 'druid:bb050dj7711')
-        expect { purl_object.update_from_public_xml! }.to raise_exception(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context 'public xml association' do
-      before do
-        purl_object.update(druid: 'druid:bb050dj7711')
-        purl_object.update_from_public_xml!
-      end
-
-      it 'stores the public xml in the database' do
-        expect(purl_object.public_xml&.data).to be_present.and include '<publicObject id="druid:bb050dj7711"'
-      end
     end
   end
 

--- a/spec/services/purl_xml_updater_spec.rb
+++ b/spec/services/purl_xml_updater_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe PurlXmlUpdater, type: :model do
+  let(:purl_object) { create(:purl) }
+  let(:druid) { 'druid:bb050dj7711' }
+  let(:instance) { described_class.new(purl_object) }
+
+  describe '#update' do
+    subject { instance.update }
+
+    context 'when valid' do
+      before do
+        purl_object.update(druid: 'druid:bb050dj7711')
+        instance.update
+      end
+
+      it 'updates an instance from public xml' do
+        purl_object.update(druid: 'druid:bb050dj7711')
+        instance.update
+        expect(purl_object.druid).to eq 'druid:bb050dj7711'
+        expect(purl_object.title).to eq 'This is Pete\'s New Test title for this object.'
+        expect(purl_object.release_tags.count).to eq 3
+        expect(purl_object.collections.count).to eq 2
+        expect(purl_object.published_at.iso8601).to eq '2015-04-09T20:20:16Z' # should be in UTC
+        expect(purl_object.deleted_at).to be_nil
+        expect(purl_object.public_xml&.data).to be_present.and include '<publicObject id="druid:bb050dj7711"'
+      end
+    end
+
+    context 'when public xml is unavailable' do
+      it { is_expected.to be false }
+    end
+
+    context 'when validations fail' do
+      before do
+        create(:purl, druid: 'druid:bb050dj7711')
+        purl_object.update(druid: 'druid:bb050dj7711')
+      end
+
+      it 'raises an exception' do
+        expect { instance.update }.to raise_exception(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This extract the Public XML update into a service.  Later we can swap the service that does the cocina update in