### PR TITLE
Read from posted cocina json data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,11 +33,21 @@ Layout/EmptyLineBetweenDefs:
 # Configuration parameters: AllowURI, URISchemes.
 Layout/LineLength:
   Max: 132
+  AllowURI: true
   Exclude:
     - 'spec/features/v1/docs_controller_spec.rb'
 
+Lint/BooleanSymbol:
+  Enabled: false # We have a few uses of `:true` and `:false` as hash keys here.
+
 Metrics/AbcSize:
   Max: 30
+
+RSpec/MultipleExpectations:
+  Max: 7
+
+RSpec/NestedGroups:
+  Max: 4
 
 Style/StringLiterals:
   Enabled: false
@@ -45,5 +55,3 @@ Style/StringLiterals:
 Style/Documentation:
   Enabled: false
 
-RSpec/MultipleExpectations:
-  Max: 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,13 +85,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
   Exclude:
     - 'spec/models/release_tag_spec.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Lint/BooleanSymbol:
-  Exclude:
-    - 'app/services/purl_parser.rb'
-    - 'spec/features/purl_parser_spec.rb'
-
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine

--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'cocina-models'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
+    attr_extras (7.1.0)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -109,6 +110,22 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cocina-models (0.89.1)
+      activesupport
+      deprecation
+      dry-struct (~> 1.0)
+      dry-types (~> 1.1)
+      edtf
+      equivalent-xml
+      jsonpath
+      nokogiri
+      openapi3_parser
+      openapi_parser (>= 0.11.1, < 1.0)
+      rss
+      super_diff
+      thor
+      zeitwerk (~> 2.1)
+    commonmarker (0.23.8)
     concurrent-ruby (1.2.2)
     config (4.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -119,6 +136,8 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     deep_merge (1.2.2)
+    deprecation (1.1.0)
+      activesupport
     diff-lcs (1.5.0)
     dlss-capistrano (4.3.1)
       capistrano (~> 3.0)
@@ -147,6 +166,11 @@ GEM
       dry-logic (>= 1.5, < 2)
       dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
+    dry-struct (1.6.0)
+      dry-core (~> 1.0, < 2)
+      dry-types (>= 1.7, < 2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
     dry-types (1.7.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
@@ -159,6 +183,10 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    edtf (3.1.1)
+      activesupport (>= 3.0, < 8.0)
+    equivalent-xml (0.6.0)
+      nokogiri (>= 1.4.3)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -170,6 +198,7 @@ GEM
     honeybadger (5.2.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -180,6 +209,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    jsonpath (1.1.2)
+      multi_json
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -206,6 +237,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.6.1)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.4)
       date
@@ -226,9 +258,15 @@ GEM
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     okcomputer (1.18.4)
+    openapi3_parser (0.9.2)
+      commonmarker (~> 0.17)
+    openapi_parser (0.15.0)
+    optimist (3.0.1)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -285,6 +323,8 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rss (0.2.9)
+      rexml
     rubocop (1.48.1)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -323,6 +363,10 @@ GEM
       net-ssh (>= 2.8.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    super_diff (0.9.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.2.1)
     timeout (0.3.2)
     turbo-rails (1.4.0)
@@ -356,6 +400,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rvm
   capybara
+  cocina-models
   config
   debug
   dlss-capistrano

--- a/app/models/cocina_data.rb
+++ b/app/models/cocina_data.rb
@@ -1,0 +1,54 @@
+class CocinaData
+  # @param [Cocina::Models::Collection, Cocina::Models::DRO]
+  def initialize(cocina_object)
+    @cocina_object = cocina_object
+  end
+
+  attr_reader :cocina_object
+
+  # @return [String] The druid in the form of druid:pid
+  def canonical_druid
+    cocina_object.externalIdentifier
+  end
+
+  # @return [String] The catkey. An empty string is returned if there is no catkey
+  def catkey
+    catalog_record_ids('symphony').first || ''
+  end
+
+  # DSA adds the release tags from all collections this object is a member of.
+  # What code consumes the release tags here.
+  # https://github.com/sul-dlss/dor-services-app/blob/main/app/services/publish/metadata_transfer_service.rb#L22
+  # @return [Hash] A hash of all trues and falses in the form of {:true => ['Target1', 'Target2'], :false => ['Target3', 'Target4']}
+  def releases
+    { true: [], false: [] }.tap do |releases|
+      cocina_object.administrative.releaseTags.each do |tag|
+        releases[tag.release ? :true : :false] << tag.to
+      end
+    end
+  end
+
+  # @return [String] The title of the object
+  def title
+    Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title)
+  end
+
+  # @return [String] The object type
+  def object_type
+    # See https://github.com/sul-dlss/dor-services-app/blob/main/app/services/publish/public_xml_service.rb#L91
+    cocina_object.collection? ? 'collection' : 'item'
+  end
+
+  # @return [Array<String>] The collections the item is a member of
+  def collections
+    # see https://github.com/sul-dlss/dor-services-app/blob/f51bbcea710b7612f251a3922c5164ec69ba39aa/app/services/published_relationships_filter.rb#L31
+    cocina_object.dro? ? cocina_object.structural.isMemberOf : []
+  end
+
+  private
+
+  # from https://github.com/sul-dlss/dor-services-app/blob/f51bbcea710b7612f251a3922c5164ec69ba39aa/app/services/publish/public_xml_service.rb#L99
+  def catalog_record_ids(catalog)
+    Array(cocina_object.identification&.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == catalog }
+  end
+end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -48,8 +48,9 @@ class Purl < ApplicationRecord
   end
 
   ##
-  # Return true targets with always values only if the object is not deleted in
-  # purl mount
+  # Release tags where the value is true or is one of the default targets. If the object has been deleted, it retuns blank.
+  # This is consumed by
+  # https://github.com/sul-dlss/searchworks_traject_indexer/blob/64359399e8f670ed414b1c56c648dc9b95ad6bad/lib/traject/readers/kafka_purl_fetcher_reader.rb#L26 # rubocop:disable Layout:LineLength
   # @return [Array]
   def true_targets
     return [] unless deleted_at.nil?
@@ -58,7 +59,8 @@ class Purl < ApplicationRecord
   end
 
   ##
-  # Convenience method for accessing false targets
+  # Release tags with the value false.
+  # This is consumed by https://github.com/sul-dlss/searchworks_traject_indexer/blob/64359399e8f670ed414b1c56c648dc9b95ad6bad/lib/traject/readers/kafka_purl_fetcher_reader.rb#L49
   # @return [Array]
   def false_targets
     release_tags.where(release_type: false).map(&:name)

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -1,0 +1,38 @@
+# Updates the Purl database record using information from the public xml
+class PurlCocinaUpdater
+  # @param [Purl] active_record
+  # @param [Cocina::Models::Collection, Cocina::Models::DRO] cocina_object
+  def initialize(active_record, cocina_object)
+    @active_record = active_record
+    @cocina_data = CocinaData.new(cocina_object)
+  end
+
+  attr_reader :active_record, :cocina_data
+
+  delegate :collections, :releases, to: :cocina_data
+
+  def attributes
+    {
+      druid: cocina_data.canonical_druid,
+      title: cocina_data.title,
+      object_type: cocina_data.object_type,
+      catkey: cocina_data.catkey,
+      published_at: Time.current,
+      deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
+    }
+  end
+
+  def update
+    active_record.attributes = attributes
+
+    ##
+    # Delete all of the collection assocations, and then add back ones in the
+    # public xml
+    active_record.refresh_collections(collections)
+
+    # add the release tags, and reuse tags if already associated with this PURL
+    active_record.refresh_release_tags(releases)
+
+    active_record.save!
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,19 @@
 Rails.application.routes.draw do
   root 'v1/docs#stats'
 
-  scope module: :v1, constraints: ApiConstraint.new(version: 1) do
-    resource :docs, :defaults => { :format => 'json' }, :only => [:get] do
+  scope module: :v1, constraints: ApiConstraint.new(version: 1), defaults: { format: :json } do
+    resource :docs, :only => [:get] do
       get 'deletes'
       get 'changes'
     end
 
-    resources :purls, defaults: { format: :json }, only: [:index, :show, :destroy], param: :druid do
+    resources :purls, only: [:index, :show, :destroy], param: :druid do
       member do
         post '/', action: 'update'
       end
     end
 
-    resources :collections, defaults: { format: :json }, only: [:index, :show], param: :druid  do
+    resources :collections, only: [:index, :show], param: :druid  do
       member do
         get 'purls'
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 require 'net/http'
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'cocina/rspec'
 require 'json'
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
dor-services-app is now posting cocina to purl-fetcher.  This gives us the opportunity to use the data provided over the API and avoid loading the public xml from the filesystem. 