### PR TITLE
Exclude extra metadata from the cocina model

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -47,7 +47,9 @@ module V1
     private
 
       def cocina_object
-        Cocina::Models.build(params.except(:action, :controller, :druid, :purl, :format).to_unsafe_h)
+        # TODO: Remove the :created, :modified, :lock exclusions when
+        # https://github.com/sul-dlss/cocina-models/commit/5d97fbd1e65554a8870a14449776ed68c3d5eb26 is released
+        Cocina::Models.build(params.except(:action, :controller, :druid, :purl, :format, :created, :modifed, :lock).to_unsafe_h)
       end
 
       def filter_params

--- a/spec/requests/v1/purls_controller_spec.rb
+++ b/spec/requests/v1/purls_controller_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe V1::PurlsController do
     context 'with cocina json' do
       let(:headers) { { 'Content-Type' => 'application/json' } }
       let(:data) do
-        build(:dro, title: "The Information Paradox for Black Holes",
-                    collection_ids: ['druid:xb432gf1111'])
+        build(:dro_with_metadata, title: "The Information Paradox for Black Holes",
+                                  collection_ids: ['druid:xb432gf1111'])
           .new(administrative: {
                  hasAdminPolicy: "druid:hv992ry2431",
                  releaseTags: [


### PR DESCRIPTION
This was a shortcoming revealed in integration testing in stage. 

Fixes #575 