### PR TITLE
Move cocina processing to a background job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,9 @@ Metrics/AbcSize:
 RSpec/MultipleExpectations:
   Max: 7
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 6
+  
 RSpec/NestedGroups:
   Max: 4
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-rvm'
-  gem 'dlss-capistrano'
+  gem 'dlss-capistrano', '~> 4.4'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.5.0)
-    dlss-capistrano (4.3.1)
+    dlss-capistrano (4.4.0)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -413,7 +413,7 @@ DEPENDENCIES
   cocina-models
   config
   debug
-  dlss-capistrano
+  dlss-capistrano (~> 4.4)
   druid-tools
   factory_bot_rails
   honeybadger

--- a/app/consumers/purl_updates_consumer.rb
+++ b/app/consumers/purl_updates_consumer.rb
@@ -1,10 +1,11 @@
 class PurlUpdatesConsumer < Racecar::Consumer
   subscribes_to "purl-update"
 
-  # Currently this is a no-op until we are able to set up a systemd script to run racecar
-  def process(_message)
-    # json = JSON.parse(message.value)}
-    # purl = Purl.find_or_create_by(druid: json.fetch('druid'))
-    # PurlXmlUpdater.new(purl).update
+  # Update the Purl database record with Cocina data passed in the message
+  def process(message)
+    json = JSON.parse(message.value)
+    cocina_object = Cocina::Models.build(json)
+    purl = Purl.find_by!(druid: cocina_object.externalIdentifier)
+    PurlCocinaUpdater.new(purl, cocina_object).update
   end
 end

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -29,15 +29,14 @@ module V1
               end
 
       if params[:type]
-        # Racecar.produce_sync(value: cocina_object.to_json, key: druid_param, topic: "purl-update")
-        PurlCocinaUpdater.new(@purl, cocina_object).update
+        Racecar.produce_sync(value: cocina_object.to_json, key: druid_param, topic: "purl-update")
       else
         # This path is a fallback used until dor-services-app is providing the data we need
         Honeybadger.notify("Cocina JSON was not provided. Falling back to xml", context: { druid: druid_param })
         PurlXmlUpdater.new(@purl).update
       end
 
-      render json: true
+      render json: true, status: :accepted
     end
 
     def destroy

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,6 +10,10 @@ end
 
 set :deploy_to, "/opt/app/lyberadmin/purl-fetcher"
 
+# Manage sneakers via systemd (from dlss-capistrano gem)
+set :racecar_systemd_role, :worker
+set :racecar_systemd_use_hooks, true
+
 # Default value for :linked_files is []
 set :linked_files, %w{config/secrets.yml config/database.yml config/honeybadger.yml config/newrelic.yml}
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,4 @@
-server "purl-fetcher-prod.stanford.edu", user: 'lyberadmin', roles: %w{web db app}
+server "purl-fetcher-prod.stanford.edu", user: 'lyberadmin', roles: %w{web db app worker}
 
 set :bundle_without, %w(test deployment development).join(' ')
 

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,4 +1,4 @@
-server "purl-fetcher-stage.stanford.edu", user: 'lyberadmin', roles: %w{web db app}
+server "purl-fetcher-stage.stanford.edu", user: 'lyberadmin', roles: %w{web db app worker}
 
 set :bundle_without, %w(test deployment development).join(' ')
 

--- a/spec/consumers/purl_updates_consumer_spec.rb
+++ b/spec/consumers/purl_updates_consumer_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PurlUpdatesConsumer do
+  let(:message) { instance_double(Racecar::Message, value: message_value) }
+  let!(:purl_object) { create(:purl) }
+
+  let(:message_value) do
+    build(:dro, id: purl_object.druid,
+                title: "The Information Paradox for Black Holes",
+                collection_ids: ['druid:xb432gf1111'])
+      .new(administrative: {
+             hasAdminPolicy: "druid:hv992ry2431",
+             releaseTags: [
+               { to: 'Searchworks', release: true },
+               { to: 'Earthworks', release: false }
+             ]
+           })
+      .to_json
+  end
+
+  before do
+    described_class.new.process(message)
+  end
+
+  it "updates the purl record with the provided data" do
+    purl_object.reload
+    expect(purl_object.title).to eq "The Information Paradox for Black Holes"
+    expect(purl_object.true_targets).to eq ["Searchworks", "SearchWorksPreview", "ContentSearch"]
+    expect(purl_object.false_targets).to eq ['Earthworks']
+    expect(purl_object.collections.size).to eq 1
+    expect(purl_object.collections.first.druid).to eq 'druid:xb432gf1111'
+  end
+end


### PR DESCRIPTION
Fixes #530

This has been tested on stage and handled a 17,000 item collection with no problem.