### PR TITLE
Extract a method for producing a reindex message

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,23 @@ Name | Located In | Description | Required | Schema | Default
 
 ## Administration
 
+### Reindexing
+You can create Kafka messages that will cause all the Purls to be reindexed by doing:
+```ruby
+Purl.unscoped.find_in_batches.with_index do |group, batch|
+  puts "Processing group ##{batch}"
+  group.each(&:produce_indexer_log_message)
+end
+```
+
+Or only for searchworks:
+```ruby
+ReleaseTag.where(name: 'Searchworks').find_in_batches.with_index do |group, batch|
+  puts "Processing group ##{batch}"
+  group.each { |rt| rt.purl.produce_indexer_log_message }
+end
+```
+
 ### Reporting
 
 The API's internals use an [ActiveRecord data model](http://guides.rubyonrails.org/active_record_querying.html) to manage various information

--- a/app/consumers/purl_updates_consumer.rb
+++ b/app/consumers/purl_updates_consumer.rb
@@ -8,10 +8,7 @@ class PurlUpdatesConsumer < Racecar::Consumer
     purl = Purl.find_by!(druid: cocina_object.externalIdentifier)
     PurlCocinaUpdater.new(purl, cocina_object).update
 
-    produce(purl.as_public_json.to_json,
-            key: cocina_object.externalIdentifier,
-            topic: Settings.indexer_topic)
-    deliver!
+    purl.produce_indexer_log_message
   rescue StandardError => e
     Honeybadger.notify(e)
     raise e

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -47,6 +47,11 @@ class Purl < ApplicationRecord
     results
   end
 
+  # Sends a message to the indexer_topic, which will cause this object to be reindexed
+  def produce_indexer_log_message
+    Racecar.produce_sync(value: as_public_json.to_json, topic: Settings.indexer_topic, key: druid)
+  end
+
   def as_public_json
     data = if deleted?
              as_json(only: %i[druid])

--- a/spec/consumers/purl_updates_consumer_spec.rb
+++ b/spec/consumers/purl_updates_consumer_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe PurlUpdatesConsumer do
   let(:consumer) { described_class.new }
 
   before do
-    allow(consumer).to receive(:produce)
-    allow(consumer).to receive(:deliver!)
+    allow(Racecar).to receive(:produce_sync)
   end
 
   context 'without errors' do
@@ -36,9 +35,8 @@ RSpec.describe PurlUpdatesConsumer do
       expect(purl_object.false_targets).to eq ['Earthworks']
       expect(purl_object.collections.size).to eq 1
       expect(purl_object.collections.first.druid).to eq 'druid:xb432gf1111'
-      expect(consumer).to have_received(:produce)
-        .with(String, key: purl_object.druid, topic: 'testing_topic')
-      expect(consumer).to have_received(:deliver!)
+      expect(Racecar).to have_received(:produce_sync)
+        .with(value: String, key: purl_object.druid, topic: 'testing_topic')
     end
   end
 


### PR DESCRIPTION
This will enable us to reindex all the purls.

```ruby
Purl.unscoped.find_in_batches.with_index do |group, batch|
  puts "Processing group ##{batch}"
  group.each(&:produce_indexer_log_message)
end
```

Or only for Searchworks:
```ruby
ReleaseTag.where(name: 'Searchworks').find_in_batches.with_index do |group, batch|
  puts "Processing group ##{batch}"
  group.each { |rt| rt.purl.produce_indexer_log_message }
end
```

Fixes #622 