### PR TITLE
Add support for async kafka production, which may increase dump performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,11 @@ end
 
 Or only for searchworks:
 ```ruby
-ReleaseTag.where(name: 'Searchworks').find_in_batches.with_index do |group, batch|
+Purl.target('Searchworks').find_in_batches.with_index do |group, batch|
   puts "Processing group ##{batch}"
-  group.each { |rt| rt.purl.produce_indexer_log_message }
+  Racecar.wait_for_delivery do
+    group.each { |purl| purl.produce_indexer_log_message(async: true) }
+  end
 end
 ```
 

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -48,8 +48,12 @@ class Purl < ApplicationRecord
   end
 
   # Sends a message to the indexer_topic, which will cause this object to be reindexed
-  def produce_indexer_log_message
-    Racecar.produce_sync(value: as_public_json.to_json, topic: Settings.indexer_topic, key: druid)
+  def produce_indexer_log_message(async: false)
+    if async
+      Racecar.produce_async(value: as_public_json.to_json, topic: Settings.indexer_topic, key: druid)
+    else
+      Racecar.produce_sync(value: as_public_json.to_json, topic: Settings.indexer_topic, key: druid)
+    end
   end
 
   def as_public_json


### PR DESCRIPTION
The current dump on -prod isn't able to keep ahead of the indexing consumers (~5-15 records/second). Maybe this will help.

Anecdotally, this makes a big difference and we're able to get ahead of the consumers (which are handling 30 records/second). 

The latest dump took about 70 minutes for everything (vs a projected ~8 hours with `produce_sync`). Indexing still takes time, but that's easier to scale up as needed.