### PR TITLE
Write the COCINA into the database like we were for public xml

### DIFF
--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -25,7 +25,7 @@ class PurlCocinaUpdater
       object_type: cocina_data.object_type,
       catkey: cocina_data.catkey,
       published_at: Time.current,
-      public_xml_attributes: { data: cocina_data.cocina_object&.to_json },
+      public_xml_attributes: { data: cocina_data.cocina_object&.to_json, data_type: 'cocina' },
       deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
     }
   end

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -11,6 +11,7 @@ class PurlCocinaUpdater
 
   delegate :collections, :releases, to: :cocina_data
 
+  # rubocop:disable Metrics/MethodLength
   def attributes
     title = cocina_data.title
     if title.match?(/[\u{10000}-\u{10FFFF}]/)
@@ -24,9 +25,11 @@ class PurlCocinaUpdater
       object_type: cocina_data.object_type,
       catkey: cocina_data.catkey,
       published_at: Time.current,
+      public_xml_attributes: { data: cocina_data.cocina_object&.to_json },
       deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
     }
   end
+  # rubocop:enable Metrics/MethodLength
 
   def update
     active_record.attributes = attributes

--- a/db/migrate/20230907214045_add_data_type_to_public_xml.rb
+++ b/db/migrate/20230907214045_add_data_type_to_public_xml.rb
@@ -1,0 +1,5 @@
+class AddDataTypeToPublicXml < ActiveRecord::Migration[7.0]
+  def change
+    add_column :public_xmls, :data_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2022_01_03_184105) do
     t.binary "data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "data_type"
     t.index ["purl_id"], name: "index_public_xmls_on_purl_id"
   end
 

--- a/spec/consumers/purl_updates_consumer_spec.rb
+++ b/spec/consumers/purl_updates_consumer_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe PurlUpdatesConsumer do
       expect(purl_object.false_targets).to eq ['Earthworks']
       expect(purl_object.collections.size).to eq 1
       expect(purl_object.collections.first.druid).to eq 'druid:xb432gf1111'
+      expect(purl_object.public_xml.data).to eq message_value
       expect(Racecar).to have_received(:produce_sync)
         .with(value: String, key: purl_object.druid, topic: 'testing_topic')
     end


### PR DESCRIPTION
This got dropped in https://github.com/sul-dlss/purl-fetcher/commit/cc0d79c1c773e6c32c0511b69446177e1f62a988#diff-069556c6d4037b81003bff11828bb29a0a80719659fc958657994bb276442f2cL101, but it is incredibly helpful for remediating data.