### PR TITLE
Remove workaround for cocina-models build method metadata support

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -24,14 +24,12 @@ module V1
 
     private
 
-      def title_has_utf8mb4?
-        params[:description][:title].to_s.match?(/[\u{10000}-\u{10FFFF}]/)
-      end
+    def title_has_utf8mb4?
+      params[:description][:title].to_s.match?(/[\u{10000}-\u{10FFFF}]/)
+    end
 
-      def cocina_object
-        # TODO: Remove the :created, :modified, :lock exclusions when
-        # https://github.com/sul-dlss/cocina-models/commit/5d97fbd1e65554a8870a14449776ed68c3d5eb26 is released
-        Cocina::Models.build(params.except(:action, :controller, :druid, :purl, :format, :created, :modified, :lock).to_unsafe_h)
-      end
+    def cocina_object
+      Cocina::Models.build(params.except(:action, :controller, :druid, :purl, :format).to_unsafe_h)
+    end
   end
 end

--- a/spec/requests/v1/purls_controller_spec.rb
+++ b/spec/requests/v1/purls_controller_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe V1::PurlsController do
                    { to: 'Searchworks', release: true },
                    { to: 'Earthworks', release: false }
                  ]
-               })
+               },
+               created: Time.now.utc.iso8601,
+               modified: Time.now.utc.iso8601)
       end
       let(:data) { cocina_object.to_json }
-      let(:expected_message_value) { Cocina::Models.without_metadata(cocina_object).to_json }
+      let(:expected_message_value) { Cocina::Models.build(cocina_object).to_json }
 
       context 'with a new item' do
         let(:druid) { 'druid:zz222yy2222' }


### PR DESCRIPTION
This was released in v0.90.0
