### PR TITLE
Ignore more sqlite files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@
 /log/*.txt
 /tmp
 /run/*.pid
-/db/*.sqlite3
-/db/*.sqlite3-journal
+/db/*.sqlite3*
 /log/purl_finder*
 
 /public/*.gz


### PR DESCRIPTION
Files named test.sqlite3-wal and test.sqlite3-shm are created
during tests but not ignored without this.
