### PR TITLE
Unpin racecar dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,4 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'cocina-models'
 
-gem "racecar", "~> 2.9.0.beta1"
+gem "racecar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,9 +278,9 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    racecar (2.9.0)
+    racecar (2.10.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.12.0)
+      rdkafka (~> 0.13.0)
     rack (3.0.9.1)
     rack-session (2.0.0)
       rack (>= 3.0.0)
@@ -320,7 +320,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
-    rdkafka (0.12.0)
+    rdkafka (0.13.0)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
@@ -423,6 +423,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 
@@ -447,7 +448,7 @@ DEPENDENCIES
   newrelic_rpm
   okcomputer
   puma (~> 6.0)
-  racecar (~> 2.9.0.beta1)
+  racecar
   rails (~> 7.1.2)
   rake (~> 13)
   rspec-rails (~> 6.0)


### PR DESCRIPTION
This gets us racecar 2.10.0, which fixes a bug related to Rails
7.1 (https://github.com/zendesk/racecar/issues/356).

Without it, running the PurlUpdatesConsumer as detailed in the
README throws an error and exits.
