### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,171 @@
-[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/purl-fetcher/badge.svg?branch=main)](https://coveralls.io/github/sul-dlss/purl-fetcher?branch=main)
-
+[![CI](https://github.com/sul-dlss/purl-fetcher/actions/workflows/ruby.yml/badge.svg)](https://github.com/sul-dlss/purl-fetcher/actions/workflows/ruby.yml)
 
 # purl-fetcher
 
-A web service app that queries PURL to return info needed for updating a database that can be queried via REST APIs.
+An HTTP API for querying and updating [PURL](https://github.com/sul-dlss/purl)s. See the [API section](#api) below for docs.
 
-## Setting up your environment
+## Requirements
+
+1. Ruby (3.2 or greater)
+2. [bundler](http://bundler.io/) gem
+3. [Apache Kafka](http://kafka.apache.org/) (0.10 or greater), or [Docker](https://www.docker.com/)
+
+## Installation
+
+Clone the repository:
 
 ```bash
-
 git clone https://github.com/sul-dlss/purl-fetcher.git
-
 cd purl-fetcher
-
-bundle install
-
-rake db:migrate
-rake db:migrate RAILS_ENV=test
-
 ```
 
-## Running the application
-### Web
+Install dependencies:
+
+```bash
+bundle install
+```
+
+Set up the database:
+
+```
+rake db:migrate
+```
+
+## Developing
+
+The API communicates with a Kafka broker to dispatch and process updates asynchronously. You can run a Kafka broker locally, or use the provided `docker-compose` configuration:
+
+```bash
+docker-compose up
+```
+
+Then, in a separate terminal, start a development API server:
+
 ```bash
 bin/rails server
 ```
 
-### Background workers
+Finally, in another terminal, you can run the Kafka consumer to process updates from the Kafka broker:
+
 ```bash
 bundle exec racecar PurlUpdatesConsumer
 ```
 
-## Running tests
+### Making requests
+
+You can make requests to the API using `curl` or a similar tool. To add an object to the database, you can first download its public Cocina JSON from production PURL:
 
 ```bash
-bundle exec rake
+curl https://purl.stanford.edu/bb112zx3193.json > bb112zx3193.json
 ```
 
-## API Provided (as implemented)
+Then, you can use the `POST /purls/:druid` endpoint to add the object to the database:
 
-### Purl
+```bash
+curl -X POST -H "Content-Type: application/json" -d @bb112zx3193.json http://localhost:3000/purls/bb112zx3193
+```
 
-#### `/purls`
-`GET /purls`
+After the object has been added, it will show up in the list of changes:
 
-#### Summary
-Purl Index route
-#### Description
-The `/purls` endpoint provides information about public PURL documents.
+```bash
+curl http://localhost:3000/docs/changes
+```
+
+## Testing
+
+The full test suite (with RuboCop style enforcement) can be run with the default rake task:
+
+```bash
+rake
+```
+
+The tests can be run without RuboCop style enforcement:
+
+```bash
+rake spec
+```
+
+The RuboCop style enforcement can be run without running the tests:
+
+```bash
+rake rubocop
+```
+
+## API
+
+### Purls
+
+#### `/purls/:druid`
+
+`POST /purls/:druid`
+
+##### Summary
+
+Purl Document Update
+
+##### Description
+
+The POST `/purls/:druid` endpoint provides the ability to create or update a PURL document from public Cocina JSON. This endpoint is used by [dor-services-app](https://github.com/sul-dlss/dor-services-app/) as part of SDR workflows.
+
 ##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`object_type` | query | limit requests to a specific `object_type` | No | string | null
-`membership` | query | limit requests by membership type, for instance items with no membership (collection) | No | string accepted values: `none`, `collection` | null
-`status` | query | limit requests by status of object (`deleted`, `public`) | No | string | null
-`target` | query | limit requests by release tag targets (`SearchWorks`, `Revs`) case sensitive | No | string | null
-`page` | query | request a specific page of results | No | integer | 1
-`per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
+
+| Name      | Located In | Description                                | Required | Schema                          | Default |
+| --------- | ---------- | ------------------------------------------ | -------- | ------------------------------- | ------- |
+| `druid`   | url        | Druid of a specific PURL                   | Yes      | string eg(`druid:cc1111dd2222`) | null    |
+| `version` | header     | Version of the API request eg(`version=1`) | No       | integer                         | 1       |
 
 ##### Example Response
+
+```json
+true
+```
+
+### Docs
+
+#### `/docs/changes`
+
+`GET /docs/changes`
+
+##### Summary
+
+Purl Document Changes
+
+##### Description
+
+The `/docs/changes` endpoint provides information about public PURL documents that have been changed, their release tag information and also collection association. This endpoint can be queried using [purl_fetcher-client](https://github.com/sul-dlss/purl_fetcher-client).
+
+##### Parameters
+
+| Name             | Located In | Description                                | Required | Schema              | Default                |
+| ---------------- | ---------- | ------------------------------------------ | -------- | ------------------- | ---------------------- |
+| `first_modified` | query      | Limit response by a beginning datetime     | No       | datetime in iso8601 | earliest possible date |
+| `last_modified`  | query      | Limit response by an ending datetime       | No       | datetime in iso8601 | current time           |
+| `page`           | query      | request a specific page of results         | No       | integer             | 1                      |
+| `per_page`       | query      | Limit the number of results per page       | No       | integer (1 - 10000) | 100                    |
+| `target`         | query      | Release tag to filter on                   | No       | string              | nil                    |
+| `version`        | header     | Version of the API request eg(`version=1`) | No       | integer             | 1                      |
+
+##### Example Response
+
 ```json
 {
-  "purls": [
+  "changes": [
     {
-      "druid": "druid:ee1111ff2222",
-      "published_at": "2013-01-01T00:00:00.000Z",
-      "deleted_at": "2016-01-03T00:00:00.000Z",
-      "object_type": "set",
-      "catkey": "",
-      "title": "Some test object number 4",
-      "collections": [
-        "druid:oo000oo0002"
-      ],
-      "true_targets": [
-        "SearchWorksPreview"
-      ]
+      "druid": "druid:dd111ee2222",
+      "latest_change": "2014-01-01T00:00:00Z",
+      "true_targets": ["SearchWorksPreview"],
+      "collections": ["druid:oo000oo0001"]
     },
     {
-      "druid": "druid:ff1111gg2222",
-      "published_at": "2013-01-01T00:00:00.000Z",
-      "deleted_at": "2014-01-01T00:00:00.000Z",
-      "object_type": "collection",
-      "catkey": "",
-      "title": "Some test object number 5",
-      "collections": [],
-      "true_targets": [
-        "SearchWorksPreview"
-      ]
+      "druid": "druid:bb111cc2222",
+      "latest_change": "2015-01-01T00:00:00Z",
+      "true_targets": ["SearchWorks", "Revs", "SearchWorksPreview"],
+      "collections": ["druid:oo000oo0001", "druid:oo000oo0002"]
+    },
+    {
+      "druid": "druid:aa111bb2222",
+      "latest_change": "2016-06-06T00:00:00Z",
+      "true_targets": ["SearchWorksPreview"]
     }
   ],
   "pages": {
@@ -103,145 +181,31 @@ Name | Located In | Description | Required | Schema | Default
 }
 ```
 
-#### `/purls/:druid`
-`GET /purls/:druid`
-
-##### Summary
-Purl Document Show
-##### Description
-The `/purls/:druid` endpoint provides information about a specifc PURL document.
-##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`druid` | url | Druid of a specific PURL | Yes | string eg(`druid:cc1111dd2222`) | null
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
-
-##### Example Response
-```json
-{
-  "druid": "druid:cc1111dd2222",
-  "published_at": "2016-01-01T00:00:00.000Z",
-  "deleted_at": "2016-01-02T00:00:00.000Z",
-  "object_type": "item",
-  "catkey": "567",
-  "title": "Some test object number 2",
-  "collections": [
-    "druid:oo000oo0002"
-  ],
-  "true_targets": [
-    "SearchWorksPreview"
-  ],
-  "false_targets": [
-    "SearchWorks"
-  ]
-}
-```
-
-`PATCH /purls/:druid`
-
-##### Summary
-Purl Document Update
-##### Description
-The PATCH `/purls/:druid` endpoint provides the ability to update PURL document from public xml.
-##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`druid` | url | Druid of a specific PURL | Yes | string eg(`druid:cc1111dd2222`) | null
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
-
-##### Example Response
-```json
-true
-```
-
-### Docs
-
-#### `/docs/changes`
-
-`GET /docs/changes`
-
-##### Summary
-Purl Document Changes
-##### Description
-The `/docs/changes` endpoint provides information about public PURL documents that have been changed, their release tag information and also collection association.
-##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`first_modified` | query | Limit response by a beginning datetime | No | datetime in iso8601 | earliest possible date
-`last_modified` | query | Limit response by an ending datetime| No | datetime in iso8601 | current time
-`page` | query | request a specific page of results | No | integer | 1
-`per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
-`target` | query | Release tag to filter on | No | string | nil
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
-
-##### Example Response
-```json
-{
-  "changes": [
-    {
-      "druid": "druid:dd111ee2222",
-      "latest_change": "2014-01-01T00:00:00Z",
-      "true_targets": [
-        "SearchWorksPreview"
-      ],
-      "collections": [
-        "druid:oo000oo0001"
-      ]
-    },
-    {
-      "druid": "druid:bb111cc2222",
-      "latest_change": "2015-01-01T00:00:00Z",
-      "true_targets": [
-        "SearchWorks",
-        "Revs",
-        "SearchWorksPreview"
-      ],
-      "collections": [
-        "druid:oo000oo0001",
-        "druid:oo000oo0002"
-      ]
-    },
-    {
-      "druid": "druid:aa111bb2222",
-      "latest_change": "2016-06-06T00:00:00Z",
-      "true_targets": [
-        "SearchWorksPreview"
-      ]
-    },
-  ],
-  "pages": {
-    "current_page": 1,
-    "next_page": null,
-    "prev_page": null,
-    "total_pages": 1,
-    "per_page": 100,
-    "offset_value": 0,
-    "first_page?": true,
-    "last_page?": true
-  }
-}
-```
-
-
 #### `/docs/deletes`
 
 `GET /docs/deletes`
 
 ##### Summary
+
 Purl Document Deletes
+
 ##### Description
-The `/docs/deletes` endpoint provides information about public PURL documents that have been deleted.
+
+The `/docs/deletes` endpoint provides information about public PURL documents that have been deleted. This endpoint can be queried using [purl_fetcher-client](https://github.com/sul-dlss/purl_fetcher-client).
+
 ##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`first_modified` | query | Limit response by a beginning datetime | No | datetime in iso8601 | earliest possible date
-`last_modified` | query | Limit response by an ending datetime| No | datetime in iso8601 | current time
-`page` | query | request a specific page of results | No | integer | 1
-`per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
-`target` | query | Release tag to filter on | No | string | nil
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
+
+| Name             | Located In | Description                                | Required | Schema              | Default                |
+| ---------------- | ---------- | ------------------------------------------ | -------- | ------------------- | ---------------------- |
+| `first_modified` | query      | Limit response by a beginning datetime     | No       | datetime in iso8601 | earliest possible date |
+| `last_modified`  | query      | Limit response by an ending datetime       | No       | datetime in iso8601 | current time           |
+| `page`           | query      | request a specific page of results         | No       | integer             | 1                      |
+| `per_page`       | query      | Limit the number of results per page       | No       | integer (1 - 10000) | 100                    |
+| `target`         | query      | Release tag to filter on                   | No       | string              | nil                    |
+| `version`        | header     | Version of the API request eg(`version=1`) | No       | integer             | 1                      |
 
 ##### Example Response
+
 ```json
 {
   "deletes": [
@@ -273,97 +237,29 @@ Name | Located In | Description | Required | Schema | Default
 
 ### Collections
 
-#### `/collections`
-
-`GET /collections`
-
-##### Summary
-Collections in PURL
-##### Description
-The `/collections` endpoint provides a list of collections (with druids, catkeys, and release targets)
-##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`page` | query | request a specific page of results | No | integer | 1
-`per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
-
-##### Example Response
-```json
-{
-  "collections": [
-    {
-      "druid": "druid:ff111gg2222",
-      "catkey": "",
-      "true_targets": [
-        "SearchWorksPreview"
-      ]
-    }
-  ],
-  "pages": {
-    "current_page": 1,
-    "next_page": null,
-    "prev_page": null,
-    "total_pages": 1,
-    "per_page": 100,
-    "offset_value": 0,
-    "first_page?": true,
-    "last_page?": true
-  }
-}
-```
-
-#### `/collections/:druid`
-
-`GET /collections/:druid`
-
-##### Summary
-Provides information about a single collection
-##### Description
-The `/collections/:id` endpoint provides information about a single collection.
-
-##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`druid` | url | Druid of a specific collection | Yes | string eg(`druid:cc1111dd2222`) | null
-`page` | query | request a specific page of results | No | integer | 1
-`per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
-
-##### Example Response
-```json
-{
-  "druid": "druid:ff111gg2222",
-  "published_at": "2013-01-01T00:00:00.000Z",
-  "deleted_at": "2014-01-01T00:00:00.000Z",
-  "object_type": "collection",
-  "catkey": "",
-  "title": "Some test object number 5 (a collection)",
-  "collections": [],
-  "true_targets": [
-    "SearchWorksPreview"
-  ]
-}
-```
-
 #### `/collections/:druid/purls`
 
 `GET /collections/:druid/purls`
 
 ##### Summary
+
 Collection Purls route
+
 ##### Description
-The `/collections/:druid/purls` endpoint a listing of Purls for a specific collection.
+
+The `/collections/:druid/purls` endpoint a listing of Purls for a specific collection. This endpoint is used by the [Exhibits](https://github.com/sul-dlss/exhibits) application.
 
 ##### Parameters
-Name | Located In | Description | Required | Schema | Default
----- | ---------- | ----------- | -------- | ------ | -------
-`druid` | url | Druid of a specific collection | Yes | string eg(`druid:cc1111dd2222`) | null
-`page` | query | request a specific page of results | No | integer | 1
-`per_page` | query | Limit the number of results per page | No | integer (1 - 10000) | 100
-`version` | header | Version of the API request eg(`version=1`) | No | integer | 1
+
+| Name       | Located In | Description                                | Required | Schema                          | Default |
+| ---------- | ---------- | ------------------------------------------ | -------- | ------------------------------- | ------- |
+| `druid`    | url        | Druid of a specific collection             | Yes      | string eg(`druid:cc1111dd2222`) | null    |
+| `page`     | query      | request a specific page of results         | No       | integer                         | 1       |
+| `per_page` | query      | Limit the number of results per page       | No       | integer (1 - 10000)             | 100     |
+| `version`  | header     | Version of the API request eg(`version=1`) | No       | integer                         | 1       |
 
 ##### Example Response
+
 ```json
 {
   "purls": [
@@ -413,11 +309,12 @@ Name | Located In | Description | Required | Schema | Default
 }
 ```
 
-
 ## Administration
 
 ### Reindexing
+
 You can create Kafka messages that will cause all the Purls to be reindexed by doing:
+
 ```ruby
 Purl.unscoped.find_in_batches.with_index do |group, batch|
   puts "Processing group ##{batch}"
@@ -426,6 +323,7 @@ end
 ```
 
 Or only for searchworks:
+
 ```ruby
 Purl.target('Searchworks').find_in_batches.with_index do |group, batch|
   puts "Processing group ##{batch}"


### PR DESCRIPTION
- Adds info on running local kafka broker
- Removes API docs for routes that no longer exist
- Adds an example of how to POST cocina to the API
- Switches the broken coverage badge for a CI badge
