### PR TITLE
Decouple release tags from Cocina

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ RSpec/MultipleExpectations:
   Max: 7
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 7
+  Max: 8
 
 RSpec/NestedGroups:
   Max: 4

--- a/app/consumers/purl_updates_consumer.rb
+++ b/app/consumers/purl_updates_consumer.rb
@@ -4,9 +4,10 @@ class PurlUpdatesConsumer < Racecar::Consumer
   # Update the Purl database record with Cocina data passed in the message
   def process(message)
     json = JSON.parse(message.value)
-    cocina_object = Cocina::Models.build(json)
+    cocina_object = Cocina::Models.build(json['cocina'])
+    actions = json['actions']
     purl = Purl.find_by!(druid: cocina_object.externalIdentifier)
-    PurlCocinaUpdater.new(purl, cocina_object).update
+    PurlCocinaUpdater.new(purl, cocina_object, actions).update
 
     purl.produce_indexer_log_message
   rescue StandardError => e

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -18,7 +18,15 @@ module V1
                 retry
               end
 
-      Racecar.produce_sync(value: cocina_object.to_json, key: druid_param, topic: "purl-updates")
+      # Get the actions from the release tags on the cocina model. In the near future,
+      # the releaseTags will be removed from Cocina.
+      actions = { index: [], delete: [] }.tap do |releases|
+        cocina_object.administrative.releaseTags.each do |tag|
+            releases[tag.release ? :index : :delete] << tag.to
+        end
+      end
+
+      Racecar.produce_sync(value: { cocina: cocina_object, actions: }.to_json, key: druid_param, topic: "purl-updates")
 
       render json: true, status: :accepted
     end

--- a/app/models/cocina_data.rb
+++ b/app/models/cocina_data.rb
@@ -16,18 +16,6 @@ class CocinaData
     catalog_record_ids('folio').first || catalog_record_ids('symphony').first || ''
   end
 
-  # DSA adds the release tags from all collections this object is a member of.
-  # What code consumes the release tags here.
-  # https://github.com/sul-dlss/dor-services-app/blob/main/app/services/publish/metadata_transfer_service.rb#L22
-  # @return [Hash] A hash of all trues and falses in the form of {:true => ['Target1', 'Target2'], :false => ['Target3', 'Target4']}
-  def releases
-    { true: [], false: [] }.tap do |releases|
-      cocina_object.administrative.releaseTags.each do |tag|
-        releases[tag.release ? :true : :false] << tag.to
-      end
-    end
-  end
-
   # @return [String] The title of the object
   def title
     Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title)

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -97,10 +97,10 @@ class Purl < ApplicationRecord
   end
 
   # add the release tags, and reuse tags if already associated with this PURL
-  def refresh_release_tags(releases)
-    [true, false].each do |type|
-      releases[type.to_s.to_sym].sort.uniq.each do |release|
-        release_tags << ReleaseTag.for(self, release, type)
+  def refresh_release_tags(actions)
+    ['index', 'delete'].each do |type|
+      actions[type].sort.uniq.each do |property|
+        release_tags << ReleaseTag.for(self, property, type)
       end
     end
   end

--- a/app/models/release_tag.rb
+++ b/app/models/release_tag.rb
@@ -7,9 +7,10 @@ class ReleaseTag < ApplicationRecord
   #
   # @param [Purl] `purl`
   # @param [String] `name` release tag name
-  # @param [Boolean] `release_type`
+  # @param [String] action either 'index' or 'delete'
   # @return [ReleaseTag] finds or creates a ReleaseTag record for the given tuple
-  def self.for(purl, name, release_type)
+  def self.for(purl, name, action)
+    release_type = action == 'index'
     tag = ReleaseTag.find_by(name:, purl_id: purl.id)
     if tag.present?
       tag.release_type = release_type

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -2,15 +2,17 @@
 class PurlCocinaUpdater
   # @param [Purl] active_record
   # @param [Cocina::Models::Collection, Cocina::Models::DRO] cocina_object
-  def initialize(active_record, cocina_object)
+  # @param [Hash] actions the actions to take on the index
+  def initialize(active_record, cocina_object, actions)
     @active_record = active_record
+    @actions = actions
     @cocina_data = CocinaData.new(cocina_object)
     Honeybadger.context({ cocina_object: cocina_object.to_h })
   end
 
-  attr_reader :active_record, :cocina_data
+  attr_reader :active_record, :cocina_data, :actions
 
-  delegate :collections, :releases, to: :cocina_data
+  delegate :collections, to: :cocina_data
 
   # rubocop:disable Metrics/MethodLength
   def attributes
@@ -41,7 +43,7 @@ class PurlCocinaUpdater
     active_record.refresh_collections(collections)
 
     # add the release tags, and reuse tags if already associated with this PURL
-    active_record.refresh_release_tags(releases)
+    active_record.refresh_release_tags(actions)
 
     active_record.save!
   end

--- a/spec/consumers/purl_updates_consumer_spec.rb
+++ b/spec/consumers/purl_updates_consumer_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe PurlUpdatesConsumer do
   let!(:purl_object) { create(:purl) }
   let(:title) { "The Information Paradox for Black Holes" }
   let(:message_value) do
+    {
+      cocina:,
+      actions:
+    }.to_json
+  end
+  let(:cocina) do
     build(:dro, id: purl_object.druid,
                 title:,
                 collection_ids: ['druid:xb432gf1111'])
@@ -15,7 +21,12 @@ RSpec.describe PurlUpdatesConsumer do
                { to: 'Earthworks', release: false, what: 'self' }
              ]
            })
-      .to_json
+  end
+  let(:actions) do
+    {
+      index: ['Searchworks'],
+      delete: ['Earthworks']
+    }
   end
   let(:consumer) { described_class.new }
 
@@ -35,7 +46,7 @@ RSpec.describe PurlUpdatesConsumer do
       expect(purl_object.false_targets).to eq ['Earthworks']
       expect(purl_object.collections.size).to eq 1
       expect(purl_object.collections.first.druid).to eq 'druid:xb432gf1111'
-      expect(purl_object.public_json.data).to eq message_value
+      expect(purl_object.public_json.data).to eq cocina.to_json
       expect(Racecar).to have_received(:produce_sync)
         .with(value: String, key: purl_object.druid, topic: 'testing_topic')
     end

--- a/spec/requests/v1/purls_controller_spec.rb
+++ b/spec/requests/v1/purls_controller_spec.rb
@@ -36,7 +36,15 @@ RSpec.describe V1::PurlsController do
                modified: Time.now.utc.iso8601)
       end
       let(:data) { cocina_object.to_json }
-      let(:expected_message_value) { Cocina::Models.build(cocina_object).to_json }
+      let(:expected_message_value) do
+        {
+          cocina: Cocina::Models.build(cocina_object),
+          actions: {
+            index: ['Searchworks'],
+            delete: ['Earthworks']
+          }
+        }.to_json
+      end
 
       context 'with a new item' do
         let(:druid) { 'druid:zz222yy2222' }


### PR DESCRIPTION
This will allow us to eventually remove release tags from the Cocina model. This supports versioning changes