### PR TITLE
Add a notification that shows when we're in a deprecated code path

### DIFF
--- a/app/consumers/purl_updates_consumer.rb
+++ b/app/consumers/purl_updates_consumer.rb
@@ -10,6 +10,7 @@ class PurlUpdatesConsumer < Racecar::Consumer
       cocina_object = Cocina::Models.build(json['cocina'])
       actions = json['actions']
     else
+      Honeybadger.notify("In dead code path. We should remove this once we stop seeing this code called.")
       cocina_object = Cocina::Models.build(json)
       actions = { 'index' => [], 'delete' => [] }.tap do |releases|
         cocina_object.administrative.releaseTags.each do |tag|


### PR DESCRIPTION
If we don't see this in a few weeks, we should remove it