### PR TITLE
Remove actions from publish API

### DIFF
--- a/app/consumers/purl_updates_consumer.rb
+++ b/app/consumers/purl_updates_consumer.rb
@@ -8,8 +8,6 @@ class PurlUpdatesConsumer < Racecar::Consumer
     actions = json['actions']
     purl = Purl.find_by!(druid: cocina_object.externalIdentifier)
     PurlCocinaUpdater.new(purl, cocina_object, actions).update
-
-    purl.produce_indexer_log_message
   rescue StandardError => e
     Honeybadger.notify(e)
     raise e

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -22,15 +22,7 @@ module V1
                 retry
               end
 
-      # Get the actions from the release tags on the cocina model. In the near future,
-      # the releaseTags will be removed from Cocina.
-      actions = { index: [], delete: [] }.tap do |releases|
-        cocina_object.administrative.releaseTags.each do |tag|
-            releases[tag.release ? :index : :delete] << tag.to
-        end
-      end
-
-      Racecar.produce_sync(value: { cocina: cocina_object, actions: }.to_json, key: druid_param, topic: "purl-updates")
+      Racecar.produce_sync(value: { cocina: cocina_object, actions: nil }.to_json, key: druid_param, topic: "purl-updates")
 
       render json: true, status: :accepted
     end

--- a/app/controllers/v1/released_controller.rb
+++ b/app/controllers/v1/released_controller.rb
@@ -17,10 +17,11 @@ module V1
     def update
       purl = Purl.find_by!(druid: params[:druid])
       actions = params.require(:actions).permit(index: [], delete: [])
-      cocina = purl.cocina_hash
 
-      # TODO: in the future this can just refresh_release_tags and produce_indexer_log_message
-      Racecar.produce_sync(value: { cocina:, actions: }.to_json, key: druid_param, topic: "purl-updates")
+      # add the release tags, and reuse tags if already associated with this PURL
+      purl.refresh_release_tags(actions)
+      purl.save!
+      purl.produce_indexer_log_message
 
       render json: true, status: :accepted
     end

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -42,9 +42,6 @@ class PurlCocinaUpdater
     # public xml
     active_record.refresh_collections(collections)
 
-    # add the release tags, and reuse tags if already associated with this PURL
-    active_record.refresh_release_tags(actions)
-
     active_record.save!
   end
 end

--- a/spec/consumers/purl_updates_consumer_spec.rb
+++ b/spec/consumers/purl_updates_consumer_spec.rb
@@ -42,13 +42,9 @@ RSpec.describe PurlUpdatesConsumer do
     it "updates the purl record with the provided data" do
       purl_object.reload
       expect(purl_object.title).to eq "The Information Paradox for Black Holes"
-      expect(purl_object.true_targets).to eq ["Searchworks", "SearchWorksPreview", "ContentSearch"]
-      expect(purl_object.false_targets).to eq ['Earthworks']
       expect(purl_object.collections.size).to eq 1
       expect(purl_object.collections.first.druid).to eq 'druid:xb432gf1111'
       expect(purl_object.public_json.data).to eq cocina.to_json
-      expect(Racecar).to have_received(:produce_sync)
-        .with(value: String, key: purl_object.druid, topic: 'testing_topic')
     end
   end
 

--- a/spec/requests/v1/purls_controller_spec.rb
+++ b/spec/requests/v1/purls_controller_spec.rb
@@ -41,10 +41,7 @@ RSpec.describe V1::PurlsController do
       let(:expected_message_value) do
         {
           cocina: Cocina::Models.build(cocina_object),
-          actions: {
-            index: ['Searchworks'],
-            delete: ['Earthworks']
-          }
+          actions: nil
         }.to_json
       end
 

--- a/spec/requests/v1/released_controller_spec.rb
+++ b/spec/requests/v1/released_controller_spec.rb
@@ -33,22 +33,13 @@ RSpec.describe V1::ReleasedController do
       let(:purl_object) { create(:purl) }
       let(:druid) { purl_object.druid }
       let(:cocina_object) { JSON.parse(purl_object.public_json.data) }
-      let(:expected_message_value) do
-        {
-          cocina: Cocina::Models.build(cocina_object),
-          actions: {
-            index: ['Searchworks'],
-            delete: ['Earthworks']
-          }
-        }.to_json
-      end
 
-      it 'updates the purl with new data' do
+      it 'puts a Kafka message on the queue for indexing' do
         put("/v1/released/#{druid}", params: data, headers:)
         expect(response).to have_http_status(:accepted)
 
         expect(Racecar).to have_received(:produce_sync)
-          .with(key: druid, topic: 'purl-updates', value: expected_message_value)
+          .with(key: druid, topic: 'testing_topic', value: purl_object.as_public_json.to_json)
       end
     end
 


### PR DESCRIPTION
The actions are now set in the releasetags API

Depends on https://github.com/sul-dlss/dor-services-app/pull/4970 being merged and deployed.

Ref #720 720