### PR TITLE
Add class for migrating purl and stacks data into OCFL structure 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,4 +70,6 @@ gem 'whenever', require: false
 
 gem 'jwt' # json web token
 
-gem 'ocfl'
+gem 'ocfl', '~> 0.4', '>= 0.4.1'
+
+gem 'druid-tools'

--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem "racecar"
 gem 'whenever', require: false
 
 gem 'jwt' # json web token
+
+gem 'ocfl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,13 +162,29 @@ GEM
       ed25519
     docile (1.4.0)
     drb (2.2.1)
+    dry-configurable (1.1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-inflector (1.0.0)
+    dry-initializer (3.1.1)
     dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-monads (1.6.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-schema (1.13.3)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-logic (>= 1.4, < 2)
+      dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
     dry-struct (1.6.0)
       dry-core (~> 1.0, < 2)
@@ -265,6 +281,12 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
+    ocfl (0.4.0)
+      activesupport (>= 7.0)
+      dry-monads (~> 1.6)
+      dry-schema (~> 1.13)
+      dry-struct (~> 1.6)
+      zeitwerk (~> 2.0)
     okcomputer (1.18.5)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
@@ -451,6 +473,7 @@ DEPENDENCIES
   kaminari
   mysql2
   newrelic_rpm
+  ocfl
   okcomputer
   puma (~> 6.0)
   racecar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
       ed25519
     docile (1.4.0)
     drb (2.2.1)
+    druid-tools (3.0.0)
     dry-configurable (1.1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
@@ -281,7 +282,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
-    ocfl (0.4.0)
+    ocfl (0.4.1)
       activesupport (>= 7.0)
       dry-monads (~> 1.6)
       dry-schema (~> 1.13)
@@ -466,6 +467,7 @@ DEPENDENCIES
   config
   debug
   dlss-capistrano (~> 4.4)
+  druid-tools
   factory_bot_rails
   honeybadger
   jbuilder
@@ -473,7 +475,7 @@ DEPENDENCIES
   kaminari
   mysql2
   newrelic_rpm
-  ocfl
+  ocfl (~> 0.4, >= 0.4.1)
   okcomputer
   puma (~> 6.0)
   racecar

--- a/app/services/ocfl_migrator.rb
+++ b/app/services/ocfl_migrator.rb
@@ -1,0 +1,43 @@
+# For a given druid, migrates files from the Purl and Stacks mounts to an OCFL structure
+class OcflMigrator
+  def self.migrate(...)
+    new(...).migrate
+  end
+
+  # @param [String] druid
+  def initialize(druid:)
+    @druid = druid
+  end
+
+  def migrate
+    builder.copy_recursive(stacks_druid_path)
+    builder.copy_recursive(purl_druid_path)
+    builder.save
+  end
+
+  private
+
+  attr_reader :druid
+
+  def builder
+    @builder ||= OCFL::Object::DirectoryBuilder.new(object_root: ocfl_druid_path, id: druid)
+  end
+
+  def purl_druid_path
+    DruidTools::PurlDruid
+      .new(druid, Settings.filesystems.purl_root)
+      .path
+  end
+
+  def stacks_druid_path
+    DruidTools::StacksDruid
+      .new(druid, Settings.filesystems.stacks_root)
+      .path
+  end
+
+  def ocfl_druid_path
+    DruidTools::AccessDruid
+      .new(druid, Settings.filesystems.ocfl_root)
+      .path
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,3 +9,9 @@ always_send_true_targets:
 indexer_topic: testing_topic
 
 hmac_secret: ~
+
+# Mounted filesystems
+filesystems:
+  ocfl_root: '/stacks/ocfl'
+  purl_root: '/purl/document_cache'
+  stacks_root: '/stacks'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,7 @@
 hmac_secret: 'my$ecretK3y'
+
+# Mounted filesystems
+filesystems:
+  ocfl_root: 'tmp/ocfl'
+  purl_root: 'tmp/purl_doc_cache'
+  stacks_root: 'tmp/stacks'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,1 +1,7 @@
 hmac_secret: 'my$ecretK3y'
+
+# Mounted filesystems
+filesystems:
+  ocfl_root: 'tmp/ocfl'
+  purl_root: 'tmp/purl_doc_cache'
+  stacks_root: 'tmp/stacks'

--- a/spec/services/ocfl_migrator_spec.rb
+++ b/spec/services/ocfl_migrator_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OcflMigrator do
+  subject(:migrator) { described_class.new(druid:) }
+
+  let(:druid) { 'druid:mn023nf6127' }
+
+  around do |example|
+    example.run
+  ensure
+    FileUtils.rm_rf(Dir.glob("#{Settings.filesystems.ocfl_root}/*"))
+  end
+
+  describe '.migrate' do
+    before { allow(described_class).to receive(:new).and_return(fake_instance) }
+
+    let(:fake_instance) { instance_double(described_class, migrate: nil) }
+
+    it 'invokes #migrate on a new instance' do
+      described_class.migrate(druid:)
+      expect(fake_instance).to have_received(:migrate).once
+    end
+  end
+
+  describe '#migrate' do
+    before do
+      allow(OCFL::Object::DirectoryBuilder).to receive(:new).and_return(fake_builder)
+      migrator.migrate
+    end
+
+    let(:fake_builder) { instance_double(OCFL::Object::DirectoryBuilder, copy_recursive: nil, save: nil) }
+
+    it 'copies files from the stacks path' do
+      expect(fake_builder).to have_received(:copy_recursive).with(/#{Settings.filesystems.stacks_root}/).once
+    end
+
+    it 'copies files from the purl path' do
+      expect(fake_builder).to have_received(:copy_recursive).with(/#{Settings.filesystems.purl_root}/).once
+    end
+
+    it 'saves the OCFL object directory' do
+      expect(fake_builder).to have_received(:save).once
+    end
+  end
+end


### PR DESCRIPTION
Fixes #698 

Here's what the migrator does:

Given this stacks structure

```shell
tmp/stacks
└── mn
    └── 023
        └── nf
            └── 6127
                └── my-icons-collection
                    ├── license
                    │   └── license.pdf
                    └── png
                        ├── arrow-up-on-a-black-circle-background.png
                        ├── group.png
                        ├── passage-of-time.png
                        └── user.png

```

And this purl structure:

```shell
tmp/purl_doc_cache
└── mn
    └── 023
        └── nf
            └── 6127
                ├── cocina.json
                ├── mods
                └── public
```

then produce this OCFL structure:

```shell
tmp/ocfl
└── mn
    └── 023
        └── nf
            └── 6127
                ├── 0=ocfl_object_1.1
                ├── inventory.json
                ├── inventory.json.sha512
                └── v1
                    ├── content
                    │   ├── cocina.json
                    │   ├── mods
                    │   ├── my-icons-collection
                    │   │   ├── license
                    │   │   │   └── license.pdf
                    │   │   └── png
                    │   │       ├── arrow-up-on-a-black-circle-background.png
                    │   │       ├── group.png
                    │   │       ├── passage-of-time.png
                    │   │       └── user.png
                    │   └── public
                    ├── inventory.json
                    └── inventory.json.sha512
```