### PR TITLE
Fix migration on MySql

### DIFF
--- a/db/migrate/20240509152306_create_table_constituent_memberships.rb
+++ b/db/migrate/20240509152306_create_table_constituent_memberships.rb
@@ -1,8 +1,8 @@
 class CreateTableConstituentMemberships < ActiveRecord::Migration[7.1]
   def change
     create_table :constituent_memberships do |t|
-      t.belongs_to :parent, null: false, foreign_key: { to_table: :purls }
-      t.belongs_to :child, null: false, foreign_key:  { to_table: :purls }
+      t.belongs_to :parent, null: false, foreign_key: { to_table: :purls }, type: :integer
+      t.belongs_to :child, null: false, foreign_key:  { to_table: :purls }, type: :integer
       t.integer :sort_order, null: false
 
       t.timestamps


### PR DESCRIPTION
The purls table used integer type keys, but now the default is bigint, (https://github.com/rails/rails/pull/26266), so we need to be explicit

Fixes #726 