### PR TITLE
Bump up the max message size

### DIFF
--- a/config/initializers/racecar.rb
+++ b/config/initializers/racecar.rb
@@ -1,4 +1,4 @@
 Racecar.configure do |config|
   # Each config variable can be set using a writer attribute.
-  config.producer = ['message.max.bytes=10485760']
+  config.producer = ['message.max.bytes=26214400']
 end


### PR DESCRIPTION
we have some 11mb+ cocina documents (e.g. rm242zg2446).