### PR TITLE
Add MODS endpoint for Argo

### DIFF
--- a/app/controllers/v1/mods_controller.rb
+++ b/app/controllers/v1/mods_controller.rb
@@ -1,0 +1,11 @@
+module V1
+  class ModsController < ApplicationController
+    # Given a POST body with cocina, transform it to MODS xml. Used by Argo to preview metadata
+    def create
+      public_cocina = Cocina::Models.build(params[:mods].to_unsafe_h)
+      desc_metadata_service = Publish::PublicDescMetadataService.new(public_cocina, [])
+      desc_md_xml = desc_metadata_service.ng_xml(include_access_conditions: false)
+      render xml: desc_md_xml.to_xml
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -3,12 +3,9 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, "\\1en"
-#   inflect.singular /^(ox)en/i, "\\1"
-#   inflect.irregular "person", "people"
-#   inflect.uncountable %w( fish sheep )
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.uncountable %w( mods )
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,6 @@ Rails.application.routes.draw do
   scope 'v1', module: :v1 do
     resources :direct_uploads, only: :create, as: :rails_direct_upload
     resources :released, only: :update, param: :druid
+    resource :mods, only: :create
   end
 end

--- a/spec/requests/v1/mods_spec.rb
+++ b/spec/requests/v1/mods_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "Mods export" do
+  let(:headers) { { 'Content-Type' => 'application/json' } }
+  let(:data) { build(:dro).to_json }
+
+  it 'updates the purl with new data' do
+    post("/v1/mods", params: data, headers:)
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+        <titleInfo>
+          <title>factory DRO title</title>
+        </titleInfo>
+        <location>
+          <url usage="primary display">https://purl.stanford.edu/bc234fg5678</url>
+        </location>
+      </mods>
+    XML
+  end
+end


### PR DESCRIPTION
Allows Argo to dump XML creation.  It can call this as a service.

Fixes #742 