### PR TITLE
Prototype publish api

### DIFF
--- a/app/controllers/v1/resources_controller.rb
+++ b/app/controllers/v1/resources_controller.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module V1
+  class ResourcesController < ApplicationController
+    include Authenticated
+
+    class BlobError < StandardError; end
+
+    before_action :check_auth_token, only: %i[create]
+
+    # POST /resource
+    def create
+      begin
+        @druid = cocina_object.externalIdentifier
+        shelve_files
+        unshelve_removed_files
+        location = write_purl
+      rescue BlobError => e
+        # Returning 500 because not clear whose fault it is.
+        return render build_error('500', e, 'Error matching uploading files to file parameters.')
+      end
+
+      render json: true, location:, status: :created
+    end
+
+    private
+
+    attr_reader :druid
+
+    # return [String] the Purl path for the druid
+    def purl_druid_path
+      DruidTools::PurlDruid.new(druid, Settings.filesystems.purl_root).path
+    end
+
+    # return [String] the Stacks path for the druid
+    def stacks_druid_path
+      DruidTools::PurlDruid.new(druid, Settings.filesystems.stacks_root).path
+    end
+
+    # Write the cocina object to the Purl druid path as cocina.json
+    # return [String] the path to the written cocina.json file
+    def write_purl
+      cocina_json_path = File.join(purl_druid_path, 'cocina.json')
+      FileUtils.mkdir_p(purl_druid_path) unless File.directory?(purl_druid_path)
+      File.write(cocina_json_path, cocina_object.to_json)
+
+      purl = begin
+        Purl.find_or_create_by(druid:)
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      Racecar.produce_sync(value: { cocina: cocina_object, actions: nil }.to_json, key: druid, topic: "purl-updates")
+
+      purl
+    end
+
+    CREATE_PARAMS_EXCLUDE_FROM_COCINA = %i[action controller resource].freeze
+
+    def cocina_object_params
+      params.except(*CREATE_PARAMS_EXCLUDE_FROM_COCINA).to_unsafe_h
+    end
+
+    # Build the cocina object from the params
+    def cocina_object
+      cocina_model_params = cocina_object_params.deep_dup
+      @cocina_object ||= Cocina::Models.build(cocina_model_params)
+    end
+
+    # return [Array<Cocina::Models::FileSet>] the file sets in the cocina object
+    def file_sets
+      cocina_object.structural.contains
+    end
+
+    # Copy the files from ActiveStorage to the Stacks directory
+    def shelve_files
+      file_sets.each do |fileset|
+        fileset.structural.contains.each do |file|
+          next unless signed_id?(file.externalIdentifier)
+
+          blob = blob_for_signed_id(file.externalIdentifier, file.filename)
+          blob_path = ActiveStorage::Blob.service.path_for(blob.key)
+          FileUtils.mkdir_p(stacks_druid_path) unless File.directory?(stacks_druid_path)
+
+          shelving_path = File.join(stacks_druid_path, file.filename)
+          FileUtils.cp(blob_path, shelving_path) unless File.exist?(shelving_path)
+        end
+      end
+    end
+
+    # return [ActiveStorage::Blob] the blob for the signed id
+    def blob_for_signed_id(signed_id, filename)
+      file_id = ActiveStorage.verifier.verified(signed_id, purpose: :blob_id)
+      ActiveStorage::Blob.find(file_id)
+    rescue ActiveRecord::RecordNotFound
+      raise BlobError, "Unable to find upload for #{filename} (#{signed_id})"
+    end
+
+    # Remove files from the Stacks directory that are not in the cocina object
+    def unshelve_removed_files
+      Dir.glob("#{stacks_druid_path}/**/*") do |file_with_path|
+        file = File.basename(file_with_path)
+        next if file_in_cocina?(file)
+
+        File.delete(file_with_path)
+      end
+    end
+
+    # return [Boolean] whether the file is in the cocina object baesd on filename
+    def file_in_cocina?(file_on_disk)
+      cocina_object.structural.contains.map do |fileset|
+        fileset.structural.contains.select { |file| file.filename == file_on_disk }
+      end.flatten.any?
+    end
+
+    # return [Boolean] whether the file_id is an ActiveStorage signed_id
+    def signed_id?(file_id)
+      ActiveStorage.verifier.valid_message?(file_id)
+    end
+
+    # JSON-API error response. See https://jsonapi.org/.
+    def build_error(error_code, err, msg)
+      {
+        json: {
+          errors: [
+            {
+              status: error_code,
+              title: msg,
+              detail: err.message
+            }
+          ]
+        },
+        content_type: 'application/vnd.api+json',
+        status: error_code
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,5 +26,6 @@ Rails.application.routes.draw do
     resources :direct_uploads, only: :create, as: :rails_direct_upload
     resources :released, only: :update, param: :druid
     resource :mods, only: :create
+    resources :resources, only: :create
   end
 end

--- a/spec/factories/active_storage_blobs.rb
+++ b/spec/factories/active_storage_blobs.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :active_storage_blob, class: 'ActiveStorage::Blob' do
+    sequence(:key) do |n|
+      "abc123-#{n}"
+    end
+
+    byte_size { 123 }
+    checksum { 'abcdefghijklmnopqrstuvwxyz' }
+    created_at { Time.current }
+    filename { 'file.txt' }
+  end
+
+  # NOTE: This is a bit of a FactoryBot anti-pattern: creating effectively a
+  #       singleton factory, one that is not intended to generate more than one
+  #       instance. But we're using it to avoid a bunch of duplicative manual
+  #       setup that used to cause flappy specs.
+  factory :singleton_blob_with_file, class: 'ActiveStorage::Blob' do
+    # Prevent multiple instances
+    to_create do |instance|
+      attributes = instance.class.find_or_create_by(instance.attributes.compact).attributes
+      instance.attributes = attributes.except('id')
+      instance.id = attributes['id'] # id can't be mass-assigned
+      instance.instance_variable_set(:@new_record, false) # marks record as persisted
+    end
+
+    key { 'tozuehlw6e8du20vn1xfzmiifyok' }
+    filename { 'file2.txt' }
+    content_type { 'application/text' }
+    byte_size { 10 }
+    checksum { 'f5nXiniiM+u/gexbNkOA/A==' }
+
+    # Put the blob's "file" in the expected place
+    after(:create) do |blob|
+      path_to_blob_file = ActiveStorage::Blob.services.fetch('test').path_for(blob.key)
+      FileUtils.mkdir_p(File.dirname(path_to_blob_file))
+      File.write(path_to_blob_file, 'HELLO')
+    end
+  end
+end

--- a/spec/requests/v1/publish_dro_spec.rb
+++ b/spec/requests/v1/publish_dro_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'base64'
+
+RSpec.describe 'Publish a DRO' do
+  let(:bare_druid) { 'bc123df4567' }
+  let(:druid) { "druid:#{bare_druid}" }
+  let(:dro) { build(:dro_with_metadata, id: druid).new(structural:) }
+  let(:request) { dro.to_json }
+  let(:contains) do
+    [
+      Cocina::Models::FileSet.new(
+        externalIdentifier: 'bc123df4567_2',
+        type: Cocina::Models::FileSetType.file,
+        label: 'text file',
+        version: 1,
+        structural: Cocina::Models::FileSetStructural.new(
+          contains: [
+            Cocina::Models::File.new(
+              externalIdentifier: signed_id,
+              type: Cocina::Models::ObjectType.file,
+              label: 'the text file',
+              filename: 'file2.txt',
+              version: 1,
+              hasMessageDigests: [
+                { type: 'md5', digest: Base64.decode64(blob.checksum).unpack1('H*') }
+              ]
+            )
+          ]
+        )
+      )
+    ]
+  end
+  let(:structural) do
+    Cocina::Models::DROStructural.new(
+      contains:
+    )
+  end
+  let(:blob) { create(:singleton_blob_with_file) }
+  let(:signed_id) do
+    ActiveStorage.verifier.generate(blob.id, purpose: :blob_id)
+  end
+
+  before do
+    allow(Racecar).to receive(:produce_sync)
+  end
+
+  context 'when a cocina object is received' do
+    it 'creates the cocina json file for the resource' do
+      post '/v1/resources',
+           params: request,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_created
+      expect(File).to exist('tmp/purl_doc_cache/bc/123/df/4567/cocina.json')
+      expect(File).to exist('tmp/stacks/bc/123/df/4567/file2.txt')
+    end
+  end
+
+  context 'when blob not found for file' do
+    let(:signed_id) { ActiveStorage.verifier.generate('thisisinvalid', purpose: :blob_id) }
+
+    it 'returns 500' do
+      post '/v1/resources',
+           params: request,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:server_error)
+      expect(JSON.parse(response.body)['errors'][0]['title']).to eq 'Error matching uploading files to file parameters.' # rubocop:disable Rails/ResponseParsedBody
+    end
+  end
+
+  context 'when file is not found in the cocina object' do
+    before do
+      File.write('tmp/stacks/bc/123/df/4567/file3.txt', 'hello world')
+    end
+
+    it 'deletes the file' do
+      expect(File).to exist('tmp/stacks/bc/123/df/4567/file3.txt')
+      post '/v1/resources',
+           params: request,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_created
+      expect(File).not_to exist('tmp/stacks/bc/123/df/4567/file3.txt')
+    end
+  end
+end

--- a/spec/requests/v1/publish_dro_spec.rb
+++ b/spec/requests/v1/publish_dro_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'Publish a DRO' do
            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_created
       expect(File).to exist('tmp/purl_doc_cache/bc/123/df/4567/cocina.json')
+      expect(File).to exist('tmp/purl_doc_cache/bc/123/df/4567/public.xml')
       expect(File).to exist('tmp/stacks/bc/123/df/4567/file2.txt')
     end
   end


### PR DESCRIPTION
Closes #718 

This is a basic, **prototype**, publish API. 

This:
- [x] moves files that have a valid ActiveStorage signed_id to the stacks path for the druid
- [x] Remoes files from the stacks path for the druid if the filename is not in cocina
- [x] Writes the cocina.json file to the purl path
- [x] If an updated file is uploaded to active storage the existing file is overwritten

This is mostly pulled from SDR api so far.