### PR TITLE
Return a 404 if the purl doesn't exist

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -6,7 +6,7 @@ module V1
 
     # Show the public json for the object. Used by purl to know if this object should be indexed by crawlers.
     def show
-      purl = Purl.find_by(druid: druid_param)
+      purl = Purl.find_by!(druid: druid_param)
       render json: purl.as_public_json
     end
 

--- a/spec/requests/v1/purls_controller_spec.rb
+++ b/spec/requests/v1/purls_controller_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe V1::PurlsController do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("true_targets" => ["PURL sitemap", "SearchWorksPreview", "ContentSearch"])
     end
+
+    context "when the druid doesn't exist" do
+      it 'returns a 404' do
+        get "/purls/zr240vm9599"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe 'POST update' do


### PR DESCRIPTION
Fixes #48916
