### PR TITLE
Put meta.json writing behind a feature flag

### DIFF
--- a/app/services/release_service.rb
+++ b/app/services/release_service.rb
@@ -10,6 +10,8 @@ class ReleaseService
   end
 
   def self.write_meta_json(purl)
+    return unless Settings.features.write_meta_json
+
     file_path = File.join(purl.purl_druid_path, 'meta.json')
     File.write(file_path, purl.as_public_json.to_json)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,3 +18,6 @@ filesystems:
 
 purl:
   hostname: purl.stanford.edu
+
+features:
+  write_meta_json: false

--- a/spec/requests/v1/released_controller_spec.rb
+++ b/spec/requests/v1/released_controller_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe V1::ReleasedController do
       let(:meta_path) { Pathname.new(purl_druid_path) / 'meta.json' }
 
       before do
+        allow(Settings.features).to receive(:write_meta_json).and_return(true)
         FileUtils.rm_r(purl_druid_path) if File.directory?(purl_druid_path)
         FileUtils.mkdir_p(purl_druid_path)
       end


### PR DESCRIPTION
We need to disable this until the /purl filesystem is mounted as read/write (it's currently read-only).