### PR TITLE
Stop writing to releaseData

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -27,8 +27,6 @@ module Publish
 
       pub.add_child(DublinCoreService.new(desc_md_xml).ng_xml.root)
       pub.add_child(desc_metadata_service.ng_xml.root)
-      # If there are no release_tags, this prevents an empty <releaseData/> from being added
-      pub.add_child(release_xml.root) unless release_xml.xpath('//release').children.empty?
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.
 
@@ -43,21 +41,6 @@ module Publish
     private
 
     attr_reader :public_cocina
-
-    # Generate XML structure for inclusion to Purl. This data is read by purl-fetcher.
-    # @return [String] The XML release node as a string, with ReleaseDigest as the root document
-    def release_xml
-      @release_xml ||= begin
-        builder = Nokogiri::XML::Builder.new do |xml|
-          xml.releaseData do
-            public_cocina.administrative.releaseTags.each do |tag|
-              xml.release(tag.release, to: tag.to)
-            end
-          end
-        end
-        Nokogiri::XML(builder.to_xml)
-      end
-    end
 
     def constituents
       @constituents ||= VirtualObject.for(druid: public_cocina.externalIdentifier)

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -281,32 +281,6 @@ RSpec.describe Publish::PublicXmlService do
           expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>bc123df4567/wt183gy6220_00_0001.jp2</thumb>')
         end
       end
-
-      context 'when there are single release tags per target' do
-        let(:public_cocina) do
-          build(:dro, id: druid).new(administrative:)
-        end
-
-        let(:administrative) do
-          {
-            hasAdminPolicy: 'druid:hv992ry2431',
-            releaseTags: [
-              { to: 'Searchworks', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'self' },
-              { to: 'PURL sitemap', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'self' }
-            ]
-          }
-        end
-
-        it 'does not include this release data in identityMetadata' do
-          expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
-        end
-
-        it 'includes releaseData element from release tags' do
-          releases = ng_xml.xpath('/publicObject/releaseData/release')
-          expect(releases.map(&:inner_text)).to eq ['true', 'true']
-          expect(releases.pluck('to')).to eq ['Searchworks', 'PURL sitemap']
-        end
-      end
     end
 
     context 'with a collection' do
@@ -330,32 +304,6 @@ RSpec.describe Publish::PublicXmlService do
           </identityMetadata>
         XML
         expect(ng_xml.at_xpath('/publicObject/identityMetadata').to_xml).to be_equivalent_to expected
-      end
-
-      context 'when there are release tags' do
-        let(:public_cocina) do
-          build(:collection, id: druid).new(administrative:)
-        end
-
-        let(:administrative) do
-          {
-            hasAdminPolicy: 'druid:hv992ry2431',
-            releaseTags: [
-              { to: 'Searchworks', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'collection' },
-              { to: 'PURL sitemap', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'collection' }
-            ]
-          }
-        end
-
-        it 'does not include this release data in identityMetadata' do
-          expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
-        end
-
-        it 'includes releaseData element from release tags' do
-          releases = ng_xml.xpath('/publicObject/releaseData/release')
-          expect(releases.map(&:inner_text)).to eq ['true', 'true']
-          expect(releases.pluck('to')).to eq ['Searchworks', 'PURL sitemap']
-        end
       end
     end
 


### PR DESCRIPTION
We now use meta.json for release tags
Fixes #787 