### PR TITLE
Move JSON deserialization to the PublicJson class

### DIFF
--- a/app/models/public_json.rb
+++ b/app/models/public_json.rb
@@ -8,4 +8,8 @@ class PublicJson < ApplicationRecord
   def data
     ActiveSupport::Gzip.decompress(super)
   end
+
+  def cocina_hash
+    JSON.parse(data)
+  end
 end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -51,20 +51,13 @@ class Purl < ApplicationRecord
     results
   end
 
-  def cocina_hash
-    data = public_json&.data
-    return unless data
-
-    JSON.parse(data)
-  end
-
   def cocina_object=(cocina_object)
     self.public_json = PublicJson.new(data: cocina_object.to_json, data_type: 'cocina')
     @cocina_object = cocina_object
   end
 
   def cocina_object
-    @cocina_object ||= Cocina::Models.build(cocina_hash) if cocina_hash
+    @cocina_object ||= Cocina::Models.build(public_json.cocina_hash)
   end
 
   # Sends a message to the indexer_topic, which will cause this object to be reindexed


### PR DESCRIPTION
Remove unnecessary nil checks. We do not have any nil JSON anymore:
```
Purl.where(public_json: nil).count
 => 0

PublicJson.where(data: nil).count
 => 0
```