### PR TITLE
Return a 404 if an item has been deleted

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -7,7 +7,8 @@ module V1
 
     # Show the files that we have for this object. Used by DSA to know which files need to be shelved.
     def show
-      purl = Purl.find_by!(druid: druid_param)
+      # Causes a 404 for a deleted item, which might happen if a purl is deleted and then reused.
+      purl = Purl.status('public').find_by!(druid: druid_param)
       render json: { files_by_md5: purl.public_json.files_by_md5 }
     end
 

--- a/spec/requests/v1/purls_controller_spec.rb
+++ b/spec/requests/v1/purls_controller_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe V1::PurlsController do
                                               ])
     end
 
+    context "when the druid was deleted" do
+      let(:purl_object) { create(:purl, deleted_at: Time.zone.today) }
+
+      it 'returns a 404' do
+        get "/purls/#{druid}"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context "when the druid doesn't exist" do
       it 'returns a 404' do
         get "/purls/zr240vm9599"


### PR DESCRIPTION
This may happen if someone unpublishes a purl and then tries to republish it. This prevents trying to get public json when there is none

Fixes #824 