### PR TITLE
Contents + Metadata only needs paths, so we don't need to provide the whole service.

### DIFF
--- a/app/services/versioned_files_service.rb
+++ b/app/services/versioned_files_service.rb
@@ -21,12 +21,9 @@ class VersionedFilesService
   def initialize(druid:)
     @druid = druid
     @paths = Paths.new(druid:)
-    @version_manifest = VersionsManifest.new(path: @paths.versions_manifest_path)
-    @contents = Contents.new(service: self)
-    @metadata = Metadata.new(service: self)
   end
 
-  attr_reader :druid, :version_manifest
+  attr_reader :druid
 
   delegate :object_path, :content_path, :versions_path, :head_cocina_path,
            :cocina_path_for, :head_public_xml_path, :public_xml_path_for,
@@ -35,10 +32,22 @@ class VersionedFilesService
   delegate :head_version, :head_version?, :version?, :version_metadata_for,
            :withdraw, :versions, to: :version_manifest
 
-  delegate :content_md5s, :move_content, to: :@contents
+  delegate :content_md5s, :move_content, to: :contents
 
   delegate :write_cocina, :write_public_xml,
-           :delete_cocina, :delete_public_xml, to: :@metadata
+           :delete_cocina, :delete_public_xml, to: :metadata
+
+  def version_manifest
+    @version_manifest ||= VersionsManifest.new(path: @paths.versions_manifest_path)
+  end
+
+  def metadata
+    @metadata ||= Metadata.new(paths: @paths)
+  end
+
+  def contents
+    @contents ||= Contents.new(paths: @paths)
+  end
 
   # Creates or updates a version.
   # @param version [String] the version number

--- a/app/services/versioned_files_service/contents.rb
+++ b/app/services/versioned_files_service/contents.rb
@@ -1,9 +1,9 @@
 class VersionedFilesService
   # Support for managing content files.
   class Contents
-    # @param service [VersionedFilesService] the service
-    def initialize(service:)
-      @service = service
+    # @param paths [VersionedFilesService::Paths] the paths service
+    def initialize(paths:)
+      @paths = paths
     end
 
     # @return [Array<String>] the md5s for all content files
@@ -22,6 +22,6 @@ class VersionedFilesService
       content_path_for(md5:).delete
     end
 
-    delegate :content_path_for, :content_path, to: :@service
+    delegate :content_path_for, :content_path, to: :@paths
   end
 end

--- a/app/services/versioned_files_service/metadata.rb
+++ b/app/services/versioned_files_service/metadata.rb
@@ -1,9 +1,9 @@
 class VersionedFilesService
   # Support for managing cocina.json and public xml files.
   class Metadata
-    # @param service [VersionedFilesService] the service
-    def initialize(service:)
-      @service = service
+    # @param paths [VersionedFilesService::Paths] the paths service
+    def initialize(paths:)
+      @paths = paths
     end
 
     # Write the cocina.json file for a version.
@@ -55,6 +55,6 @@ class VersionedFilesService
     end
 
     delegate :cocina_path_for, :public_xml_path_for, :versions_path,
-             :head_cocina_path, :head_public_xml_path, to: :@service
+             :head_cocina_path, :head_public_xml_path, to: :@paths
   end
 end


### PR DESCRIPTION
The pattern of sending the whole service to the ~10 supporting actions + classes makes it hard for me to understand what's going on. It looks like some of these only need the paths helper, and maybe that will help my understanding.