### PR TITLE
Update DublinCoreService to take the cocina and generate needed assets internally

### DIFF
--- a/app/controllers/v1/mods_controller.rb
+++ b/app/controllers/v1/mods_controller.rb
@@ -5,8 +5,8 @@ module V1
     # Given a POST body with cocina, transform it to MODS xml. Used by Argo to preview metadata
     def create
       public_cocina = Cocina::Models.build(params[:mods].to_unsafe_h)
-      desc_metadata_service = Publish::PublicDescMetadataService.new(public_cocina, [])
-      desc_md_xml = desc_metadata_service.ng_xml(include_access_conditions: false)
+      desc_metadata_service = Publish::PublicDescMetadataService.new(public_cocina, [], include_access_conditions: false)
+      desc_md_xml = desc_metadata_service.ng_xml
       render xml: desc_md_xml.to_xml
     end
   end

--- a/app/services/publish/dublin_core_service.rb
+++ b/app/services/publish/dublin_core_service.rb
@@ -6,8 +6,9 @@ module Publish
     XMLNS_OAI_DC = 'http://www.openarchives.org/OAI/2.0/oai_dc/'
 
     # @param [Nokogiri::XML::Document] the MODS XML to generate the DublinCore for.
-    def initialize(desc_md_xml)
-      @desc_md_xml = desc_md_xml
+    def initialize(public_cocina, constituents)
+      desc_metadata_service = PublicDescMetadataService.new(public_cocina, constituents, include_access_conditions: false)
+      @desc_md_xml = desc_metadata_service.ng_xml
     end
 
     # Generates Dublin Core from the MODS in the descMetadata datastream using the LoC mods2dc stylesheet

--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -3,16 +3,16 @@
 module Publish
   # Creates the descriptive XML that we display on purl.stanford.edu
   class PublicDescMetadataService
-    attr_reader :cocina_object, :constituents
+    attr_reader :cocina_object, :constituents, :include_access_conditions
 
     MODS_NS = 'http://www.loc.gov/mods/v3'
 
     # @param [Cocina::Models::Collection,Cocina::Models::DRO] cocina_object
     # @param [Array<Hash>] constituents a list of constituents (virtual object members) that are part of this object
-    def initialize(cocina_object, constituents)
+    def initialize(cocina_object, constituents, include_access_conditions: true)
       @cocina_object = cocina_object
       @constituents = constituents
-      @ng_xml = {}
+      @include_access_conditions = include_access_conditions
     end
 
     # @return [Nokogiri::XML::Document] A copy of the descriptiveMetadata of the object, to be modified
@@ -27,14 +27,14 @@ module Publish
       #        for a bug in libxml2 that the Nokogiri maintainers don't want to
       #        address in Rubyland. They recommend using `#gsub` on the string
       #        returned from `#to_xml`: https://github.com/sparklemotion/nokogiri/issues/1356
-      ng_xml(include_access_conditions: true)
+      ng_xml
         .to_xml
         .gsub('&#13;', "\r")
     end
 
     # @return [Nokogiri::XML::Document]
-    def ng_xml(include_access_conditions: true)
-      @ng_xml[include_access_conditions] ||= begin
+    def ng_xml
+      @ng_xml ||= begin
         add_collection_reference!
         AccessConditions.add(public_mods: doc, access: cocina_object.access) if include_access_conditions
         add_constituent_relations!

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -22,11 +22,9 @@ module Publish
       pub.add_child(public_content_metadata.root) if public_content_metadata.xpath('//resource').any?
       pub.add_child(public_rights_metadata)
       pub.add_child(public_relationships.root)
-      desc_metadata_service = PublicDescMetadataService.new(public_cocina, constituents)
-      desc_md_xml = desc_metadata_service.ng_xml(include_access_conditions: false)
 
-      pub.add_child(DublinCoreService.new(desc_md_xml).ng_xml.root)
-      pub.add_child(desc_metadata_service.ng_xml.root)
+      pub.add_child(DublinCoreService.new(public_cocina, constituents).ng_xml.root)
+      pub.add_child(PublicDescMetadataService.new(public_cocina, constituents).ng_xml.root)
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.
 

--- a/spec/services/publish/dublin_core_service_spec.rb
+++ b/spec/services/publish/dublin_core_service_spec.rb
@@ -3,12 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Publish::DublinCoreService do
-  subject(:service) { described_class.new(desc_md_xml) }
+  subject(:service) { described_class.new(cocina_object, []) }
 
   let(:cocina_object) do
     build(:dro, id: 'druid:bc123df4567').new(description:)
   end
-  let(:desc_md_xml) { Publish::PublicDescMetadataService.new(cocina_object, []).ng_xml(include_access_conditions: false) }
 
   describe '#ng_xml' do
     subject(:xml) { service.ng_xml }


### PR DESCRIPTION
This fixes #858 by making sure we're not accidentally sharing state.

Alternative to #860 .