### PR TITLE
Use a distinct parameter name for released#index.

### DIFF
--- a/app/controllers/v1/released_controller.rb
+++ b/app/controllers/v1/released_controller.rb
@@ -7,7 +7,7 @@ module V1
     # Query for all druids that have a certain release tag.
     # This is used by the sitemap generator in PURL.
     def show
-      release_tag = params[:id]
+      release_tag = params[:release_tag]
       purls = Purl.published
                   .status('public')
                   .target(release_tag).pluck(:druid, :updated_at)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'v1/docs#stats'
 
   scope module: :v1, constraints: ApiConstraint.new(version: 1), defaults: { format: :json } do
-    resources :released, only: :show
+    resources :released, only: :show, param: :release_tag
 
     resources :purls, only: [:destroy, :show], param: :druid do
       member do


### PR DESCRIPTION
It's a little disconcerting if `show` uses `id` and update uses `druid`...