### PR TITLE
Parse version numbers as integers

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -19,7 +19,7 @@ module V1
       @purl.mark_deleted
 
       # TODO: Once DSA is providing the version, || '1' can be removed.
-      PurlAndStacksService.delete(purl: @purl, version: params[:version] || '1')
+      PurlAndStacksService.delete(purl: @purl, version: params[:version]&.to_i || 1)
       Racecar.produce_sync(value: nil, key: druid_param, topic: Settings.indexer_topic)
     end
 

--- a/app/controllers/v1/resources_controller.rb
+++ b/app/controllers/v1/resources_controller.rb
@@ -66,7 +66,7 @@ module V1
     def version
       version = resource_params[:version]
       # TODO: Once DSA is providing the version, || '1' can be removed.
-      version || '1'
+      version&.to_i || 1
     end
 
     def must_version

--- a/app/services/versioned_files_service/delete_action.rb
+++ b/app/services/versioned_files_service/delete_action.rb
@@ -32,7 +32,7 @@ class VersionedFilesService
     delegate :head_version, :delete_cocina, :delete_public_xml, :version_manifest, :version?, to: :@service
 
     def new_head_version
-      @new_head_version ||= head_version == "1" ? nil : (head_version.to_i - 1).to_s
+      @new_head_version ||= head_version == 1 ? nil : (head_version.to_i - 1)
     end
   end
 end

--- a/spec/requests/v1/publish_dro_spec.rb
+++ b/spec/requests/v1/publish_dro_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Publish a DRO' do
   end
   let(:file_uploads) { { 'file2.txt' => 'd7e54aed-c0c4-48af-af93-bc673f079f9a', 'files/file2.txt' => '7f807e3c-4cde-4b6d-8e76-f24455316a01' } }
   let(:must_version) { false }
-  let(:version) { '1' }
+  let(:version) { 1 }
   let(:version_date) { DateTime.now }
 
   let(:contains) do

--- a/spec/requests/v1/unpublish_spec.rb
+++ b/spec/requests/v1/unpublish_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Unpublish a Purl' do
 
           expect(response).to have_http_status(:success)
           expect(VersionedFilesService).to have_received(:new).with(druid:)
-          expect(service).to have_received(:delete).with(version: '2')
+          expect(service).to have_received(:delete).with(version: 2)
         end
       end
 

--- a/spec/services/versioned_files_service_spec.rb
+++ b/spec/services/versioned_files_service_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe VersionedFilesService do
     context 'when the manifest has the head version' do
       before do
         FileUtils.mkdir_p("#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions")
-        manifest = { head: '3' }
+        manifest = { head: 3 }
         File.write("#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions/versions.json", manifest.to_json)
       end
 
       it 'returns the head version' do
-        expect(service.head_version).to eq('3')
+        expect(service.head_version).to eq(3)
       end
     end
 
@@ -50,26 +50,26 @@ RSpec.describe VersionedFilesService do
     context 'when the version manifest exists' do
       before do
         FileUtils.mkdir_p("#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions")
-        manifest = { versions: { '1': { withdrawn: false, date: '2022-06-26T10:06:45−07:00' } } }
+        manifest = { versions: { 1 => { withdrawn: false, date: '2022-06-26T10:06:45−07:00' } } }
         File.write("#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions/versions.json", manifest.to_json)
       end
 
       context 'when a version' do
         it 'returns true' do
-          expect(service.version?(version: '1')).to be true
+          expect(service.version?(version: 1)).to be true
         end
       end
 
       context 'when not a version' do
         it 'returns false' do
-          expect(service.version?(version: '2')).to be false
+          expect(service.version?(version: 2)).to be false
         end
       end
     end
 
     context 'when the version manifest does not exist' do
       it 'returns false' do
-        expect(service.version?(version: '1')).to be false
+        expect(service.version?(version: 1)).to be false
       end
     end
   end
@@ -78,26 +78,26 @@ RSpec.describe VersionedFilesService do
     context 'when the version manifest exists' do
       before do
         FileUtils.mkdir_p("#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions")
-        manifest = { versions: { '1': { withdrawn: false, date: '2022-06-26T10:06:45+07:00' } } }
+        manifest = { versions: { 1 => { withdrawn: false, date: '2022-06-26T10:06:45+07:00' } } }
         File.write("#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions/versions.json", manifest.to_json)
       end
 
       context 'when a version' do
         it 'returns version metadata' do
-          expect(service.version_metadata_for(version: '1')).to eq VersionedFilesService::VersionMetadata.new(false, DateTime.iso8601('2022-06-26T10:06:45+07:00'))
+          expect(service.version_metadata_for(version: 1)).to eq VersionedFilesService::VersionMetadata.new(false, DateTime.iso8601('2022-06-26T10:06:45+07:00'))
         end
       end
 
       context 'when not a version' do
         it 'raises UnknownVersionError' do
-          expect { service.version_metadata_for(version: '2') }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 2 not found')
+          expect { service.version_metadata_for(version: 2) }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 2 not found')
         end
       end
     end
 
     context 'when the version manifest does not exist' do
       it 'raises UnknownVersionError' do
-        expect { service.version_metadata_for(version: '1') }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 1 not found')
+        expect { service.version_metadata_for(version: 1) }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 1 not found')
       end
     end
   end
@@ -110,36 +110,36 @@ RSpec.describe VersionedFilesService do
 
       before do
         FileUtils.mkdir_p(File.dirname(versions_manifest_path))
-        manifest = { versions: { '1': { withdrawn: false, date: '2022-06-26T10:06:45+07:00' } } }
+        manifest = { versions: { 1 => { withdrawn: false, date: '2022-06-26T10:06:45+07:00' } } }
         File.write(versions_manifest_path, manifest.to_json)
       end
 
       context 'when withdrawing' do
         it 'sets withdrawn to true' do
-          service.withdraw(version: '1')
-          expect(service.version_metadata_for(version: '1').withdrawn?).to be true
+          service.withdraw(version: 1)
+          expect(service.version_metadata_for(version: 1).withdrawn?).to be true
           expect(versions_manifest[:versions]['1'][:withdrawn]).to be true
         end
       end
 
       context 'when unwithdrawing' do
         it 'sets withdrawn to false' do
-          service.withdraw(version: '1', withdrawn: false)
-          expect(service.version_metadata_for(version: '1').withdrawn?).to be false
+          service.withdraw(version: 1, withdrawn: false)
+          expect(service.version_metadata_for(version: 1).withdrawn?).to be false
           expect(versions_manifest[:versions]['1'][:withdrawn]).to be false
         end
       end
 
       context 'when not a version' do
         it 'raises UnknownVersionError' do
-          expect { service.withdraw(version: '2') }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 2 not found')
+          expect { service.withdraw(version: 2) }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 2 not found')
         end
       end
     end
 
     context 'when the version manifest does not exist' do
       it 'raises UnknownVersionError' do
-        expect { service.withdraw(version: '1') }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 1 not found')
+        expect { service.withdraw(version: 1) }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 1 not found')
       end
     end
   end
@@ -599,7 +599,7 @@ RSpec.describe VersionedFilesService do
         end
 
         it 'writes content files and metadata' do
-          service.update(version: '1', version_metadata:, cocina: dro, public_xml:,
+          service.update(version: 1, version_metadata:, cocina: dro, public_xml:,
                          file_transfers: {})
 
           # Retains unchanged content files
@@ -619,7 +619,7 @@ RSpec.describe VersionedFilesService do
             versions: {
               '1': { withdrawn: false, date: version_metadata.date.iso8601 }
             },
-            head: '1'
+            head: 1
           }.to_json)
         end
       end
@@ -628,7 +628,7 @@ RSpec.describe VersionedFilesService do
         let(:collection) { build(:collection_with_metadata, id: druid).new(access: { view: 'world' }) }
 
         it 'writes content files and metadata' do
-          service.update(version: '1', version_metadata:, cocina: collection, public_xml:,
+          service.update(version: 1, version_metadata:, cocina: collection, public_xml:,
                          file_transfers: {})
 
           expect(File.exist?(content_path)).to be false
@@ -644,7 +644,7 @@ RSpec.describe VersionedFilesService do
             versions: {
               '1': { withdrawn: false, date: version_metadata.date.iso8601 }
             },
-            head: '1'
+            head: 1
           }.to_json)
         end
       end
@@ -659,7 +659,7 @@ RSpec.describe VersionedFilesService do
       end
 
       it 'raises an error' do
-        expect { service.delete(version: '1') }.to raise_error(VersionedFilesService::Error, 'Only head version can be deleted')
+        expect { service.delete(version: 1) }.to raise_error(VersionedFilesService::Error, 'Only head version can be deleted')
       end
     end
 
@@ -670,7 +670,7 @@ RSpec.describe VersionedFilesService do
       end
 
       it 'raises an error' do
-        expect { service.delete(version: '2') }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 2 not found')
+        expect { service.delete(version: 2) }.to raise_error(VersionedFilesService::UnknowVersionError, 'Version 2 not found')
       end
     end
 
@@ -724,11 +724,11 @@ RSpec.describe VersionedFilesService do
       let(:initial_version_metadata) { VersionedFilesService::VersionMetadata.new(false, DateTime.now) }
 
       before do
-        write_version(content_path:, versions_path:, stacks_object_path:, cocina_object: initial_dro, public_xml:, version: '1', version_metadata: initial_version_metadata)
+        write_version(content_path:, versions_path:, stacks_object_path:, cocina_object: initial_dro, public_xml:, version: 1, version_metadata: initial_version_metadata)
       end
 
       it 'update content files and metadata' do
-        service.delete(version: '1')
+        service.delete(version: 1)
         # Deletes content files
         expect(File.exist?("#{content_path}/3e25960a79dbc69b674cd4ec67a72c62")).to be false
         expect(File.exist?("#{content_path}/5997de4d5abb55f21f652aa61b8f3aaf")).to be false
@@ -840,12 +840,12 @@ RSpec.describe VersionedFilesService do
             1 => { withdrawn: false, date: initial_version_metadata.date.iso8601 },
             2 => { withdrawn: false, date: version_2_metadata.date.iso8601 }
           },
-          head: '2'
+          head: 2
         }.to_json)
       end
 
       it 'update content files and metadata' do
-        service.delete(version: '2')
+        service.delete(version: 2)
         # Deletes content files
         expect(File.exist?("#{content_path}/3e25960a79dbc69b674cd4ec67a72c62")).to be true
         expect(File.exist?("#{content_path}/5997de4d5abb55f21f652aa61b8f3aaf")).to be false
@@ -861,9 +861,9 @@ RSpec.describe VersionedFilesService do
         # Writes version manifest
         expect(File.read("#{versions_path}/versions.json")).to eq({
           versions: {
-            1 => { withdrawn: false, date: initial_version_metadata.date.iso8601 }
+            '1' => { withdrawn: false, date: initial_version_metadata.date.iso8601 }
           },
-          head: '1'
+          head: 1
         }.to_json)
 
         # Deletes symlinks to stacks filesystem


### PR DESCRIPTION
It's a little unfortunate JSON struct keys are always integers, but we're storing numeric data there. It makes me wonder if there's a better serialization, but this seems like the first step to cleaning up all the type-casting. 