### PR TITLE
Only update the purl-fetcher database with cocina if it's for the head version.

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -19,7 +19,7 @@ module V1
 
     # POST /resource
     def create
-      PurlCocinaUpdater.new(@purl, @cocina_object, version).update
+      PurlCocinaUpdater.new(@purl, @cocina_object, version:).update if version >= @purl.version
 
       PurlAndStacksService.update(purl: @purl, cocina_object: @cocina_object, file_uploads:, version:, version_date:, must_version:)
 

--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -19,7 +19,7 @@ module V1
 
     # POST /resource
     def create
-      PurlCocinaUpdater.new(@purl, @cocina_object).update
+      PurlCocinaUpdater.new(@purl, @cocina_object, version).update
 
       PurlAndStacksService.update(purl: @purl, cocina_object: @cocina_object, file_uploads:, version:, version_date:, must_version:)
 

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -155,4 +155,8 @@ class Purl < ApplicationRecord
     public_json&.delete
     save!
   end
+
+  def version
+    super.to_i
+  end
 end

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -8,13 +8,14 @@ class PurlCocinaUpdater
 
   # @param [Purl] active_record
   # @param [Cocina::Models::Collection, Cocina::Models::DRO] cocina_object
-  def initialize(active_record, cocina_object)
+  def initialize(active_record, cocina_object, version: nil)
     @active_record = active_record
     @cocina_data = CocinaData.new(cocina_object)
+    @version = version
     Honeybadger.context({ cocina_object: cocina_object.to_h })
   end
 
-  attr_reader :active_record, :cocina_data
+  attr_reader :active_record, :cocina_data, :version
 
   delegate :collections, :constituents, to: :cocina_data
 
@@ -32,6 +33,7 @@ class PurlCocinaUpdater
       catkey: cocina_data.catkey,
       published_at: Time.current,
       cocina_object: cocina_data.cocina_object,
+      version:,
       deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
     }
   end

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -8,6 +8,7 @@ class PurlCocinaUpdater
 
   # @param [Purl] active_record
   # @param [Cocina::Models::Collection, Cocina::Models::DRO] cocina_object
+  # @param [Integer] version
   def initialize(active_record, cocina_object, version: nil)
     @active_record = active_record
     @cocina_data = CocinaData.new(cocina_object)

--- a/db/migrate/20240725185215_add_version_to_purls.rb
+++ b/db/migrate/20240725185215_add_version_to_purls.rb
@@ -1,0 +1,5 @@
+class AddVersionToPurls < ActiveRecord::Migration[7.1]
+  def change
+    add_column :purls, :version, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_152306) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_185215) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -93,6 +93,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_152306) do
     t.datetime "published_at", precision: nil
     t.text "title"
     t.string "catkey"
+    t.integer "version"
     t.index ["deleted_at"], name: "index_purls_on_deleted_at"
     t.index ["druid"], name: "index_purls_on_druid", unique: true
     t.index ["object_type"], name: "index_purls_on_object_type"


### PR DESCRIPTION
I don't know if this is an expected case, but it seems like out-of-order delivery could happen and should be guarded against?