### PR TITLE
Update the version manifest before removing files from disk.

### DIFF
--- a/app/services/versioned_files_service/delete_action.rb
+++ b/app/services/versioned_files_service/delete_action.rb
@@ -15,12 +15,13 @@ class VersionedFilesService
 
       raise VersionedFilesService::Error, "Only head version can be deleted" unless head_version == version
 
+      new_head_version = calculate_new_head_version
+      # Update the version manifest.
+      version_manifest.delete_version(version:, new_head_version:)
       # Delete the cocina version file and set the new head symlink.
       delete_cocina(version:, new_head_version:)
       # Delete the public xml version file and set the new head symlink.
       delete_public_xml(version:, new_head_version:)
-      # Update the version manifest.
-      version_manifest.delete_version(version:, new_head_version:)
       # Delete the content files that aren't referenced by any cocina version files.
       PurgeContentAction.new(object: @object).call
     end
@@ -31,8 +32,8 @@ class VersionedFilesService
 
     delegate :head_version, :delete_cocina, :delete_public_xml, :version_manifest, :version_metadata, :version?, to: :@object
 
-    def new_head_version
-      @new_head_version ||= head_version == 1 ? nil : version_metadata.reject { |x| x.version == @version || x.withdrawn }.last&.version
+    def calculate_new_head_version
+      head_version == 1 ? nil : version_metadata.reject { |x| x.version == @version || x.withdrawn }.last&.version
     end
   end
 end


### PR DESCRIPTION
... so we don't have to worry about dangling pointers if something goes wrong.