### PR TITLE
Logging during publish

### DIFF
--- a/app/controllers/v1/purls_controller.rb
+++ b/app/controllers/v1/purls_controller.rb
@@ -19,9 +19,13 @@ module V1
 
     # POST /resource
     def create
+      logger.info "Starting CocinaUpdater for #{@purl.druid}"
       PurlCocinaUpdater.new(@purl, @cocina_object, version:).update if version >= @purl.version
+      logger.info "Finished CocinaUpdater for #{@purl.druid}"
 
+      logger.info "Starting PurlAndStacksService update for #{@purl.druid}"
       PurlAndStacksService.update(purl: @purl, cocina_object: @cocina_object, file_uploads:, version:, version_date:, must_version:)
+      logger.info "Finished PurlAndStacksService update for #{@purl.druid}"
 
       render json: true, location: @purl, status: :created
     end


### PR DESCRIPTION
To help diagnose some timeouts it would be helpful to add a bit of logging around service calls during publish.
