### PR TITLE
Handle purls missing a public json record.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,5 +19,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake
-      - name: Run tests (with content addressed storage feature flag enabled)
-        run: SETTINGS__FEATURES__AWFL_METADATA=true SETTINGS__FEATURES__AWFL=true bundle exec rake
+      - name: Run tests
+        run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,6 +18,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake
       - name: Run tests
         run: bundle exec rake

--- a/app/services/files_by_md5_service.rb
+++ b/app/services/files_by_md5_service.rb
@@ -38,6 +38,10 @@ class FilesByMd5Service
   end
 
   def unversioned_files_by_md5
+    # Check for handling purls mistakenly lacking a PublicJson record. Remove check once all have been republished.
+    # See https://github.com/sul-dlss/dor-services-app/issues/5181
+    return [] unless purl.public_json
+
     cocina = VersionedFilesService::Cocina.new(hash: purl.public_json.cocina_hash)
     cocina.files_by_md5.select { |md5_file| check_exists(versioned_files_object.stacks_object_path.join(md5_file.values.first)) }
   end


### PR DESCRIPTION
Temporarily prevent these items from erroring on republish because they currently are missing public JSON records. 

Tested by modifying a purl on purl-fetcher stage to have no public json and a cocina.json without currently valid cocina. Republished successfully, with no errors, creating a PublicJson record and updating the cocina.json