### PR TITLE
Store and publish content types for collection members

### DIFF
--- a/app/models/cocina_data.rb
+++ b/app/models/cocina_data.rb
@@ -27,6 +27,11 @@ class CocinaData
     cocina_object.collection? ? 'collection' : 'item'
   end
 
+  # @return [String] The content type
+  def content_type
+    Cocina::ToXml::ContentType.map(cocina_object.type) if cocina_object.dro?
+  end
+
   # @return [Array<String>] The collections the item is a member of
   def collections
     # see https://github.com/sul-dlss/dor-services-app/blob/f51bbcea710b7612f251a3922c5164ec69ba39aa/app/services/published_relationships_filter.rb#L31

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -14,6 +14,7 @@ class Purl < ApplicationRecord
   validates :druid, uniqueness: true
 
   scope :object_type, ->(object_type) { where object_type: }
+  scope :content_type, ->(content_type) { where content_type: }
 
   scope :membership, lambda { |membership|
     case membership['membership']
@@ -74,7 +75,7 @@ class Purl < ApplicationRecord
     data = if deleted?
              as_json(only: %i[druid])
            else
-             as_json(only: %i[druid object_type title catkey], methods: %i[true_targets false_targets]).tap do |d|
+             as_json(only: %i[druid object_type content_type title catkey], methods: %i[true_targets false_targets]).tap do |d|
                d[:collections] = collections.pluck(:druid)
              end
            end

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -31,6 +31,7 @@ class PurlCocinaUpdater
       druid: cocina_data.canonical_druid,
       title:,
       object_type: cocina_data.object_type,
+      content_type: cocina_data.content_type,
       catkey: cocina_data.catkey,
       published_at: Time.current,
       cocina_object: cocina_data.cocina_object,

--- a/db/migrate/20250306225944_add_content_type_to_purls.rb
+++ b/db/migrate/20250306225944_add_content_type_to_purls.rb
@@ -1,0 +1,5 @@
+class AddContentTypeToPurls < ActiveRecord::Migration[8.0]
+  def change
+    add_column :purls, :content_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_07_25_185215) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_06_225944) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -94,6 +94,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_25_185215) do
     t.text "title"
     t.string "catkey"
     t.integer "version"
+    t.string "content_type"
     t.index ["deleted_at"], name: "index_purls_on_deleted_at"
     t.index ["druid"], name: "index_purls_on_druid", unique: true
     t.index ["object_type"], name: "index_purls_on_object_type"

--- a/spec/factories/public_jsons.rb
+++ b/spec/factories/public_jsons.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     data do
       Cocina::RSpec::Factories.build(:dro_with_metadata, id: purl.druid)
                               .new(access: { view: 'world' },
+                                   type: Cocina::Models::ObjectType.image,
                                    structural: {
                                      contains: [
                                        {

--- a/spec/factories/purl.rb
+++ b/spec/factories/purl.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     title { 'Some test object' }
     object_type { 'item' }
+    content_type { 'image' }
     published_at { 1.day.ago }
     public_json { association :public_json, purl: instance }
 

--- a/spec/requests/v1/collections_controller_spec.rb
+++ b/spec/requests/v1/collections_controller_spec.rb
@@ -12,5 +12,11 @@ RSpec.describe V1::CollectionsController do
       data = JSON.parse(response.body, symbolize_names: true)
       expect(data[:purls].pluck(:druid)).to match_array(purls.map(&:druid))
     end
+
+    it 'purls have content type' do
+      get "/collections/#{collection.druid}/purls"
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data[:purls].pluck(:content_type)).to match_array(purls.map(&:content_type))
+    end
   end
 end

--- a/spec/services/purl_cocina_updater_spec.rb
+++ b/spec/services/purl_cocina_updater_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PurlCocinaUpdater do
   let(:purl) { create(:purl) }
   let(:cocina) do
     build(:dro, id: purl.druid,
+                type: Cocina::Models::ObjectType.image,
                 collection_ids: ['druid:xb432gf1111'])
   end
 
@@ -26,6 +27,10 @@ RSpec.describe PurlCocinaUpdater do
     it "adds collection memberships" do
       expect(purl.collections.pluck(:druid)).to eq ["druid:xb432gf1111"]
       expect(purl.constituents).to be_empty
+    end
+
+    it "sets the content type" do
+      expect(purl.content_type).to eq "image"
     end
 
     context 'when the data has constituents' do


### PR DESCRIPTION
This implements storage and publishing of content type metadata
for purls, so that clients who query for collection members also
know the content type of each member.

See https://github.com/sul-dlss/purl/issues/84#issuecomment-2691156904
for discussion and a use case.
