### PR TITLE
Publish digital serials data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
-    cocina-models (0.103.1)
+    cocina-models (0.103.2)
       activesupport
       deprecation
       dry-struct (~> 1.0)

--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -17,7 +17,7 @@ module Publish
 
     # @return [Nokogiri::XML::Document] A copy of the descriptiveMetadata of the object, to be modified
     def doc
-      @doc ||= Cocina::Models::Mapping::ToMods::Description.transform(cocina_object.description, cocina_object.externalIdentifier)
+      @doc ||= Cocina::Models::Mapping::ToMods::Description.transform(cocina_object.description, cocina_object.externalIdentifier, identification: cocina_object.identification)
     end
 
     # @return [String] Public descriptive medatada XML

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -305,4 +305,21 @@ RSpec.describe Publish::PublicDescMetadataService do
       end
     end
   end
+
+  describe 'with digital serials data' do
+    let(:identification) { { catalogLinks: [{ catalog: 'folio', catalogRecordId: 'a1234', partLabel: 'May 2025', sortKey: '2025.05', refresh: true }], sourceId: 'sul:123' } }
+    let(:description) do
+      { title: [{ structuredValue: [{ value: 'stuff', type: 'main title' }] }], purl: 'https://purl.stanford.edu/bc123df4567' }
+    end
+    let(:public_mods) do
+      service.ng_xml
+    end
+
+    it 'adds the digital serials data to titleInfo' do
+      title = public_mods.search('//xmlns:titleInfo/xmlns:title')
+      part_label = public_mods.search('//xmlns:titleInfo/xmlns:partNumber')
+      expect(title.first.content).to eq('stuff')
+      expect(part_label.first.content).to eq('May 2025')
+    end
+  end
 end


### PR DESCRIPTION
Adds support for publishing to MODS digital serials data in cocina catalogLinks.