### PR TITLE
Create a log of the version migration

### DIFF
--- a/app/models/version_migration_item.rb
+++ b/app/models/version_migration_item.rb
@@ -1,0 +1,9 @@
+class VersionMigrationItem < ApplicationRecord
+  validates :status, inclusion: { in: ['not_analyzed', 'queued_for_analysis', 'found_legacy', 'found_version', 'migrated'] }
+
+  def self.create_all
+    Purl.find_each do |purl|
+      VersionMigrationItem.create(druid: purl.druid)
+    end
+  end
+end

--- a/db/migrate/20250805160756_create_version_migration_items.rb
+++ b/db/migrate/20250805160756_create_version_migration_items.rb
@@ -1,0 +1,12 @@
+class CreateVersionMigrationItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :version_migration_items do |t|
+      t.string :druid, null: false
+      t.string :status, null: false, default: 'not_analyzed'
+
+      t.timestamps
+    end
+    add_index :version_migration_items, :druid, unique: true
+    add_index :version_migration_items, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_06_225944) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_05_160756) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -95,6 +95,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_225944) do
     t.string "catkey"
     t.integer "version"
     t.string "content_type"
+    t.index ["content_type"], name: "index_purls_on_content_type"
     t.index ["deleted_at"], name: "index_purls_on_deleted_at"
     t.index ["druid"], name: "index_purls_on_druid", unique: true
     t.index ["object_type"], name: "index_purls_on_object_type"
@@ -112,6 +113,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_225944) do
     t.index ["name", "purl_id"], name: "index_release_tags_on_name_and_purl_id", unique: true
     t.index ["purl_id"], name: "index_release_tags_on_purl_id"
     t.index ["release_type"], name: "index_release_tags_on_release_type"
+  end
+
+  create_table "version_migration_items", force: :cascade do |t|
+    t.string "druid", null: false
+    t.string "status", default: "not_analyzed", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["druid"], name: "index_version_migration_items_on_druid", unique: true
+    t.index ["status"], name: "index_version_migration_items_on_status"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/models/version_migration_item_spec.rb
+++ b/spec/models/version_migration_item_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe VersionMigrationItem do
+  describe '.create_all' do
+    before do
+      Purl.create(druid: 'druid:dk120qp2074')
+    end
+
+    it 'creates a new VersionMigrationItem' do
+      expect { described_class.create_all }.to change(described_class, :count).by(1)
+      expect(described_class.last.status).to eq 'not_analyzed'
+    end
+  end
+end


### PR DESCRIPTION
This will be initialized by running the following (likely using screen)
```
rails runner -e production 'VersionMigrationItem.create_all'
```

Fixes #1008 