### PR TITLE
Bump cocina-models to allow ETDs to map datacite resource types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
-    cocina-models (0.105.0)
+    cocina-models (0.105.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
Pick up the latest cocina-models patch to address this error in stage: https://app.honeybadger.io/projects/48916/faults/122703407