### PR TITLE
Write virtual object memberships into the Cocina

### DIFF
--- a/app/services/publish/public_cocina_generator.rb
+++ b/app/services/publish/public_cocina_generator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Publish
+  # Adds the constituent (virtual object) relationships to the cocina object
+  class PublicCocinaGenerator
+    # @param [Cocina::Models::DRO, Cocina::Models::Collection] cocina
+    def initialize(cocina:)
+      @cocina = cocina
+    end
+
+    def self.generate(cocina:)
+      new(cocina: cocina).generate
+    end
+
+    def generate
+      related_resources = @cocina.description.relatedResource
+
+      augmented_description = @cocina.description.new(relatedResource: related_resources + constituent_resources)
+      @cocina.new(description: augmented_description)
+    end
+
+    private
+
+    def constituent_resources
+      VirtualObject.for(druid: @cocina.externalIdentifier).map do |virtual_object|
+        Cocina::Models::RelatedResource.new(title: [{ value: virtual_object[:title] }],
+                                            type: 'part of',
+                                            purl: purl_url(virtual_object[:id]),
+                                            displayLabel: 'Appears in')
+      end
+    end
+
+    def purl_url(druid)
+      "https://#{Settings.purl.hostname}/#{druid.delete_prefix('druid:')}"
+    end
+  end
+end

--- a/app/services/versioned_files_service/update_action.rb
+++ b/app/services/versioned_files_service/update_action.rb
@@ -25,7 +25,7 @@ class VersionedFilesService
       # For each provided content file, get the md5 from the cocina object. If the content file does not already exist for that md5, then write a new content file named by the md5.
       move_content_files
       # Write the cocina to cocina path for the version (overwriting if already exists).
-      write_cocina(version:, cocina:)
+      write_cocina(version:, cocina: Publish::PublicCocinaGenerator.generate(cocina:))
       # Write the public xml to public xml path for the version (overwriting if already exists).
       write_public_xml(version:, public_xml:)
       # Update the version manifest.

--- a/spec/services/publish/public_cocina_generator_spec.rb
+++ b/spec/services/publish/public_cocina_generator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publish::PublicCocinaGenerator do
+  subject(:doc) { described_class.generate(cocina:) }
+
+  let(:constituents) { [] }
+
+  let(:cocina) do
+    Cocina::Models.build({
+                           type: "https://cocina.sul.stanford.edu/models/book",
+                           externalIdentifier: druid,
+                           label: "Test DRO",
+                           version: 1,
+                           access:,
+                           administrative: { "hasAdminPolicy" => "druid:hy787xj5878" },
+                           description:,
+                           identification:,
+                           structural:
+                         })
+  end
+  let(:druid) { "druid:bc123df4567" }
+
+  let(:access) { {} }
+  let(:identification) { { sourceId: 'sul:123' } }
+  let(:structural) { {} }
+  let(:description) do
+    { title: [{ value: 'stuff' }], purl: 'https://purl.stanford.edu/bc123df4567' }
+  end
+
+  describe '#generate' do
+    context 'when the object is the constituent of a virtual object' do
+      let(:constituents) { [{ id: 'druid:hj097bm8879', title: 'Test DRO' }] }
+
+      before do
+        allow(VirtualObject).to receive(:for).and_return(constituents)
+      end
+
+      it 'writes the relationships into cocina' do
+        expect(doc.description.title.first.value).to eq 'stuff'
+        expect(doc.description.purl).to eq 'https://purl.stanford.edu/bc123df4567'
+        related_resource = doc.description.relatedResource.first
+        expect(related_resource.title.first.value).to eq 'Test DRO'
+        expect(related_resource.displayLabel).to eq 'Appears in'
+        expect(related_resource.purl).to eq 'https://purl.stanford.edu/hj097bm8879'
+      end
+    end
+  end
+end


### PR DESCRIPTION
We currently do this for the xml, but not the cocina. When we switched purl to look at the cocina, we no longer drew this relationship on the page

Fixes #1057