### PR TITLE
updating nokogiri and concurrent ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       super_diff
       thor
       zeitwerk (~> 2.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
@@ -268,9 +268,9 @@ GEM
     newrelic_rpm (10.5.0)
       logger
     nio4r (2.7.5)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     okcomputer (1.19.2)
       benchmark


### PR DESCRIPTION
Fixes the error from dependency update due to nokogiri and concurrent-ruby being a previous version. 