### PR TITLE
Make the copy operation atomic

### DIFF
--- a/app/services/versioned_files_service/contents.rb
+++ b/app/services/versioned_files_service/contents.rb
@@ -1,6 +1,11 @@
 class VersionedFilesService
   # Support for managing content files.
   class Contents
+    # Suffix used for the temp file written while moving content into place.
+    # The temp file lives next to the final destination so that +File.rename+
+    # is atomic (same filesystem).
+    TMP_SUFFIX = '.tmp'.freeze
+
     # @param paths [VersionedFilesService::Paths] the paths service
     def initialize(paths:)
       @paths = paths
@@ -13,9 +18,46 @@ class VersionedFilesService
       content_path.children.map { |child| child.basename.to_s }
     end
 
+    # Moves a content file into the versioned content store.
+    #
+    # Safe against process termination during a cross-filesystem copy:
+    #   * The source is copied to a sibling temp file (+<md5>.tmp+) inside the
+    #     content directory, fsynced, then atomically renamed to its final
+    #     name. A crash during the copy leaves at most the temp file; the final
+    #     destination is never visible until the rename succeeds.
+    #   * A leftover temp file from a prior interrupted run is removed at the
+    #     start of this call.
+    #   * The source is removed only after the rename has succeeded; if the
+    #     process dies before the source is removed, the caller's existing
+    #     cleanup of the transfer directory will reap it.
+    #
+    # Idempotent: returns without doing anything if the destination already
+    # exists.
+    #
+    # @param md5 [String] the md5 of the source file; also the name of the
+    #   destination.
+    # @param source_path [Pathname, String] the file being moved.
     def move_content(md5:, source_path:)
       FileUtils.mkdir_p(content_path)
-      FileUtils.mv(source_path, content_path_for(md5:))
+      dest_path = content_path_for(md5:)
+
+      if dest_path.exist?
+        Honeybadger.notify("move_content: dest_path already exists: #{dest_path}. You should check that temp path and source path have been removed!")
+        return
+      end
+
+      temp_path = temp_path_for(md5:)
+      # Reap a temp file left behind by a prior interrupted call.
+      FileUtils.rm_f(temp_path)
+
+      begin
+        copy_with_fsync(source_path, temp_path)
+        File.rename(temp_path, dest_path)
+      ensure
+        FileUtils.rm_f(temp_path)
+      end
+
+      FileUtils.rm_f(source_path)
     end
 
     def delete_content(md5:)
@@ -23,5 +65,22 @@ class VersionedFilesService
     end
 
     delegate :content_path_for, :content_path, to: :@paths
+
+    private
+
+    # Copies +source+ to +dest+ and fsyncs +dest+ before returning so the
+    # bytes are durable on disk once the call returns.
+    def copy_with_fsync(source, dest)
+      File.open(source, 'rb') do |input|
+        File.open(dest, 'wb') do |output|
+          IO.copy_stream(input, output)
+          output.fsync
+        end
+      end
+    end
+
+    def temp_path_for(md5:)
+      "#{content_path_for(md5:)}#{TMP_SUFFIX}"
+    end
   end
 end

--- a/spec/services/versioned_files_service/contents_spec.rb
+++ b/spec/services/versioned_files_service/contents_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VersionedFilesService::Contents do
+  let(:service) { described_class.new(paths: paths) }
+  let(:paths) { VersionedFilesService::Paths.new(druid: druid) }
+  let(:druid) { 'druid:bc123df4567' }
+  let(:content_path_for) { Pathname.new(content_pathname).join(md5) }
+  let(:content_pathname) { 'tmp/stacks_contents_spec/bc/123/df/4567/bc123df4567/content' }
+  let(:md5) { '41446aec93ba8d401a33b46679a7dcaa' }
+  let(:source_contents) { 'the quick brown fox' }
+  let(:source_path) { Pathname.new('tmp/transfer_contents_spec/source') }
+  let(:temp_path) { "#{content_path_for}.tmp" }
+
+  before do
+    allow(Settings.filesystems).to receive(:stacks_root).and_return('tmp/stacks_contents_spec')
+    FileUtils.rm_rf('tmp/stacks_contents_spec')
+    FileUtils.rm_rf('tmp/transfer_contents_spec')
+    FileUtils.mkdir_p(source_path.dirname)
+    File.write(source_path, source_contents)
+  end
+
+  after do
+    FileUtils.rm_rf('tmp/stacks_contents_spec')
+    FileUtils.rm_rf('tmp/transfer_contents_spec')
+  end
+
+  describe '#move_content' do
+    subject(:move) { service.move_content(md5:, source_path:) }
+
+    context 'when the destination does not exist' do
+      it 'moves the source into the content path' do
+        move
+        expect(File.read(content_path_for)).to eq(source_contents)
+      end
+
+      it 'removes the source file' do
+        move
+        expect(File.exist?(source_path)).to be false
+      end
+
+      it 'does not leave a temp file behind' do
+        move
+        expect(File.exist?(temp_path)).to be false
+      end
+    end
+
+    context 'when the destination already exists' do
+      before do
+        FileUtils.mkdir_p(content_path_for.dirname)
+        File.write(content_path_for, 'already here')
+      end
+
+      it 'does not overwrite the existing destination' do
+        move
+        expect(File.read(content_path_for)).to eq('already here')
+      end
+
+      it 'does not remove the source' do
+        move
+        expect(File.exist?(source_path)).to be true
+      end
+
+      it 'does not leave a temp file behind' do
+        move
+        expect(File.exist?(temp_path)).to be false
+      end
+    end
+
+    context 'when a temp file from a prior interrupted run exists' do
+      before do
+        FileUtils.mkdir_p(content_path_for.dirname)
+        File.write(temp_path, 'partial garbage')
+      end
+
+      it 'removes the stale temp file before copying' do
+        move
+        expect(File.exist?(temp_path)).to be false
+      end
+
+      it 'writes the correct content to the destination' do
+        move
+        expect(File.read(content_path_for)).to eq(source_contents)
+      end
+    end
+
+    context 'when the copy fails mid-stream (simulating a cross-filesystem copy interrupted)' do
+      before do
+        allow(IO).to receive(:copy_stream).and_raise(Interrupt)
+      end
+
+      it 'propagates the error' do
+        expect { move }.to raise_error(Interrupt)
+      end
+
+      it 'does not create the destination' do
+        expect { move }.to raise_error(Interrupt)
+        expect(File.exist?(content_path_for)).to be false
+      end
+
+      it 'cleans up the partial temp file' do
+        expect { move }.to raise_error(Interrupt)
+        expect(File.exist?(temp_path)).to be false
+      end
+
+      it 'leaves the source in place for retry' do
+        expect { move }.to raise_error(Interrupt)
+        expect(File.exist?(source_path)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the server is stopped in the middle of the move to the versioned directory, we don't want to leave a partial file in place. Fixes #1151