### PR TITLE
Public label derived from title

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ gem 'jwt' # json web token
 gem "druid-tools", "~> 3.0"
 
 gem "httpx", "~> 1.4"
+
+gem "cocina_display", "~> 2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       super_diff
       thor
       zeitwerk (~> 2.1)
-    cocina_display (2.8.0)
+    cocina_display (2.9.0)
       activesupport (>= 7)
       edtf (~> 3.2)
       geo_coord (~> 0.2)
@@ -221,7 +221,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.20.0)
+    json (2.21.1)
     jsonschema_rs (0.46.10-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
     jsonschema_rs (0.46.10-x86_64-linux)
@@ -482,6 +482,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   cocina-models (~> 0.99)
+  cocina_display (~> 2.8)
   config
   debug
   dlss-capistrano (~> 6.0)

--- a/app/services/versioned_files_service/metadata.rb
+++ b/app/services/versioned_files_service/metadata.rb
@@ -9,10 +9,12 @@ class VersionedFilesService
     # Write the cocina.json file for a version.
     # @param version [String] the version number
     # @param [Cocina] the cocina object
-    def write_cocina(version:, cocina:)
+    # @param label [String] the label to merge into the cocina hash
+    def write_cocina(version:, cocina:, label:)
       FileUtils.mkdir_p(versions_path)
       cocina_path = cocina_path_for(version:)
-      cocina_path.write(self.class.deep_compact_blank(cocina.to_h).to_json)
+      cocina_hash = self.class.deep_compact_blank(cocina.to_h).merge(label:)
+      cocina_path.write(cocina_hash.to_json)
     end
 
     def self.deep_compact_blank(node)

--- a/app/services/versioned_files_service/update_action.rb
+++ b/app/services/versioned_files_service/update_action.rb
@@ -25,7 +25,7 @@ class VersionedFilesService
       # For each provided content file, get the md5 from the cocina object. If the content file does not already exist for that md5, then write a new content file named by the md5.
       move_content_files
       # Write the cocina to cocina path for the version (overwriting if already exists).
-      write_cocina(version:, cocina: Publish::PublicCocinaGenerator.generate(cocina:))
+      write_cocina(version:, cocina: public_cocina, label:)
       # Write the public xml to public xml path for the version (overwriting if already exists).
       write_public_xml(version:, public_xml:)
       # Update the version manifest.
@@ -122,6 +122,14 @@ class VersionedFilesService
 
     def content_md5s
       @content_md5s ||= @object.content_md5s
+    end
+
+    def public_cocina
+      @public_cocina ||= Publish::PublicCocinaGenerator.generate(cocina:)
+    end
+
+    def label
+      CocinaDisplay::CocinaRecord.new(public_cocina.as_json).label
     end
   end
 end

--- a/spec/services/versioned_files_service/metadata_spec.rb
+++ b/spec/services/versioned_files_service/metadata_spec.rb
@@ -20,4 +20,37 @@ RSpec.describe VersionedFilesService::Metadata do
       it { is_expected.to eq(input) }
     end
   end
+
+  describe '#write_cocina' do
+    let(:druid) { 'druid:bc123df4567' }
+    let(:stacks_pathname) { 'tmp/stacks' }
+    let(:versions_path) { "#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions" }
+    let(:paths) { VersionedFilesService::Paths.new(druid:) }
+    let(:metadata) { described_class.new(paths:) }
+    let(:cocina) { build(:dro_with_metadata, id: druid).new(access: { view: 'world', download: 'world' }) }
+
+    before do
+      allow(Settings.filesystems).to receive(:stacks_root).and_return(stacks_pathname)
+    end
+
+    after do
+      FileUtils.rm_rf(stacks_pathname)
+    end
+
+    it 'merges the given label into the written cocina json' do
+      metadata.write_cocina(version: 1, cocina:, label: 'Computed label')
+
+      written = JSON.parse(File.read("#{versions_path}/cocina.1.json"))
+      expect(written['label']).to eq 'Computed label'
+    end
+
+    it "overrides the cocina object's own label" do
+      cocina_with_label = cocina.new(label: 'Original label')
+
+      metadata.write_cocina(version: 1, cocina: cocina_with_label, label: 'Computed label')
+
+      written = JSON.parse(File.read("#{versions_path}/cocina.1.json"))
+      expect(written['label']).to eq 'Computed label'
+    end
+  end
 end

--- a/spec/services/versioned_files_service/update_action_spec.rb
+++ b/spec/services/versioned_files_service/update_action_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VersionedFilesService::UpdateAction do
+  let(:action) { described_class.new(version: 1, version_metadata:, cocina:, file_transfers: {}, object:) }
+
+  let(:druid) { 'druid:bc123df4567' }
+  let(:object) { VersionedFilesService::Object.new(druid) }
+  let(:version_metadata) { VersionedFilesService::VersionsManifest::VersionMetadata.new(version: 1, state: 'available', date: DateTime.now) }
+
+  let(:stacks_pathname) { 'tmp/stacks' }
+  let(:versions_path) { "#{stacks_pathname}/bc/123/df/4567/bc123df4567/versions" }
+
+  let(:cocina) do
+    build(:dro_with_metadata, id: druid).new(label: '',
+                                             description: { title: [{ value: "Main title" }], purl: 'https://purl.stanford.edu/bc123df4567' },
+                                             access: { view: 'world', download: 'world' })
+  end
+
+  before do
+    allow(Settings.filesystems).to receive(:stacks_root).and_return(stacks_pathname)
+  end
+
+  after do
+    FileUtils.rm_rf(stacks_pathname)
+  end
+
+  describe '#call' do
+    it 'writes the label from the public cocina into cocina.json' do
+      action.call
+
+      written = JSON.parse(File.read("#{versions_path}/cocina.1.json"))
+      expect(written['label']).to eq 'Main title'
+    end
+
+    context "when the cocina object's own label differs from its title" do
+      let(:cocina) { build(:dro_with_metadata, id: druid).new(label: 'Some other label', access: { view: 'world', download: 'world' }) }
+
+      it 'overrides it with the title-derived label' do
+        action.call
+
+        written = JSON.parse(File.read("#{versions_path}/cocina.1.json"))
+        expect(written['label']).to eq 'factory DRO title'
+      end
+    end
+  end
+end

--- a/spec/services/versioned_files_service_spec.rb
+++ b/spec/services/versioned_files_service_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe VersionedFilesService do
   describe '#update' do
     let(:access_transfer_stage) { 'tmp/access-transfer-stage' }
     let(:version_metadata) { VersionedFilesService::VersionsManifest::VersionMetadata.new(version: 1, state: 'available', date: DateTime.now) }
-    let(:compact_cocina) { VersionedFilesService::Metadata.deep_compact_blank(cocina.to_h).to_json }
+    let(:compact_cocina) do
+      label = CocinaDisplay::CocinaRecord.new(cocina.as_json).label
+      VersionedFilesService::Metadata.deep_compact_blank(cocina.to_h).merge(label:).to_json
+    end
 
     before do
       FileUtils.mkdir_p(access_transfer_stage)


### PR DESCRIPTION
When writing public cocina to the filesystem, adds a label based on the title, using CocinaDisplay (added as a dependency). This sets up the public cocina to not be dependent on a label in an incoming cocina object. A public `label` is needed for digital bookplates and in any unknown situations where we are not already using a CocinaRecord for providing a title/label. 

Got some help from Claude, esp. with specs set-up.

Tested on stage by republishing/releasing an edited item, and the label in the public cocina is updated to match the edited title. 