### PR TITLE
Use a hash when reading stored public cocina

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 An HTTP API for querying and updating [PURL](https://github.com/sul-dlss/purl)s. See the [API section](#api) below for docs. Purl-fetcher is a cache which enables the access portfolio to efficiently index and query data such as release tags and collection memberships. It is not the canonical source for any information.
 
+NOTE: Stored public cocina may no longer be valid Cocina. Avoid building cocina objects from stored cocina and create a hash instead.
+
 ## Architecture
 https://docs.google.com/drawings/d/1--7pQQlzD-_g2AyPCtNkeODTs4CTrXKKyUyxofFWc1U/edit
 

--- a/app/models/cocina_data.rb
+++ b/app/models/cocina_data.rb
@@ -50,7 +50,7 @@ class CocinaData
   end
 
   def dro?
-    !collection?
+    Cocina::Models::DRO::TYPES.include?(data_hash['type'])
   end
 
   def catalog_record_ids(catalog)

--- a/app/models/cocina_data.rb
+++ b/app/models/cocina_data.rb
@@ -1,5 +1,5 @@
 class CocinaData
-  # @param [Hash] data_hash a parsed Cocina JSON document (Collection or DRO) with string keys
+  # @param [Hash{String => Object}] cocina_hash a hash parsed from a Cocina JSON document (either Collection or DRO)
   def initialize(data_hash)
     @data_hash = data_hash
   end
@@ -33,7 +33,7 @@ class CocinaData
 
   # @return [Array<String>] The collections the item is a member of
   def collections
-    dro? ? Array(data_hash.dig('structural', 'isMemberOf')) : []
+    Array(data_hash.dig('structural', 'isMemberOf'))
   end
 
   # @return [Array<String>] The constituent druids of this object (virtual object)

--- a/app/models/cocina_data.rb
+++ b/app/models/cocina_data.rb
@@ -1,14 +1,14 @@
 class CocinaData
-  # @param [Cocina::Models::Collection, Cocina::Models::DRO]
-  def initialize(cocina_object)
-    @cocina_object = cocina_object
+  # @param [Hash] data_hash a parsed Cocina JSON document (Collection or DRO) with string keys
+  def initialize(data_hash)
+    @data_hash = data_hash
   end
 
-  attr_reader :cocina_object
+  attr_reader :data_hash
 
   # @return [String] The druid in the form of druid:pid
   def canonical_druid
-    cocina_object.externalIdentifier
+    data_hash['externalIdentifier']
   end
 
   # @return [String] The catkey. An empty string is returned if there is no catkey
@@ -18,37 +18,42 @@ class CocinaData
 
   # @return [String] The title of the object
   def title
-    Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title)
+    CocinaDisplay::CocinaRecord.new(data_hash).display_title
   end
 
   # @return [String] The object type
   def object_type
-    # See https://github.com/sul-dlss/dor-services-app/blob/main/app/services/publish/public_xml_service.rb#L91
-    cocina_object.collection? ? 'collection' : 'item'
+    collection? ? 'collection' : 'item'
   end
 
   # @return [String] The content type
   def content_type
-    Cocina::ToXml::ContentType.map(cocina_object.type) if cocina_object.dro?
+    Cocina::ToXml::ContentType.map(data_hash['type']) if dro?
   end
 
   # @return [Array<String>] The collections the item is a member of
   def collections
-    # see https://github.com/sul-dlss/dor-services-app/blob/f51bbcea710b7612f251a3922c5164ec69ba39aa/app/services/published_relationships_filter.rb#L31
-    cocina_object.dro? ? cocina_object.structural.isMemberOf : []
+    dro? ? Array(data_hash.dig('structural', 'isMemberOf')) : []
   end
 
   # @return [Array<String>] The constituent druids of this object (virtual object)
   def constituents
-    return [] unless cocina_object.dro?
+    return [] unless dro?
 
-    cocina_object.structural.hasMemberOrders.first&.members || []
+    Array(data_hash.dig('structural', 'hasMemberOrders')&.first&.dig('members'))
   end
 
   private
 
-  # from https://github.com/sul-dlss/dor-services-app/blob/f51bbcea710b7612f251a3922c5164ec69ba39aa/app/services/publish/public_xml_service.rb#L99
+  def collection?
+    Cocina::Models::Collection::TYPES.include?(data_hash['type'])
+  end
+
+  def dro?
+    !collection?
+  end
+
   def catalog_record_ids(catalog)
-    Array(cocina_object.identification&.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == catalog }
+    Array(data_hash.dig('identification', 'catalogLinks')).filter_map { |link| link['catalogRecordId'] if link['catalog'] == catalog }
   end
 end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -54,11 +54,10 @@ class Purl < ApplicationRecord
 
   def cocina_object=(cocina_object)
     self.public_json = PublicJson.new(data: cocina_object.to_json, data_type: 'cocina')
-    @cocina_object = cocina_object
   end
 
   def cocina_object
-    @cocina_object ||= Cocina::Models.build(public_json.cocina_hash)
+    public_json.cocina_hash
   end
 
   # Sends a message to the indexer_topic, which will cause this object to be reindexed

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -52,13 +52,11 @@ class Purl < ApplicationRecord
     results
   end
 
-  def cocina_object=(cocina_object)
-    self.public_json = PublicJson.new(data: cocina_object.to_json, data_type: 'cocina')
+  def cocina_hash=(cocina_hash)
+    self.public_json = PublicJson.new(data: cocina_hash.to_json, data_type: 'cocina')
   end
 
-  def cocina_object
-    public_json.cocina_hash
-  end
+  delegate :cocina_hash, to: :public_json
 
   # Sends a message to the indexer_topic, which will cause this object to be reindexed
   def produce_indexer_log_message(async: false)

--- a/app/services/cocina/to_xml/content_metadata_generator.rb
+++ b/app/services/cocina/to_xml/content_metadata_generator.rb
@@ -59,10 +59,10 @@ module Cocina
 
         index = 0
         members.each do |external_druid|
-          cocina_object = cocina_object_store.find(external_druid)
-          Array(cocina_object.structural.contains).each do |cocina_fileset|
+          cocina_hash = cocina_object_store.find(external_druid)
+          label = CocinaDisplay::CocinaRecord.new(cocina_hash).display_title
+          Array(cocina_hash.dig('structural', 'contains')).each do |cocina_fileset|
             index += 1
-            label = cocina_object.description.title.first.value
             @xml_doc.root.add_child create_external_resource_node(cocina_fileset, index, external_druid, label:)
           end
         end
@@ -139,7 +139,7 @@ module Cocina
 
       def create_external_resource_node(cocina_fileset, sequence, external_druid, label:)
         Nokogiri::XML::Node.new('resource', @xml_doc).tap do |resource|
-          resource['id'] = IdGenerator.generate_or_existing_fileset_id(resource_id: cocina_fileset.try(:externalIdentifier), druid:)
+          resource['id'] = IdGenerator.generate_or_existing_fileset_id(resource_id: cocina_fileset['externalIdentifier'], druid:)
           resource['sequence'] = sequence
           resource['type'] = type_for(cocina_fileset)
 
@@ -151,22 +151,22 @@ module Cocina
         #   <externalFile fileId="PC0170_s1_B_0540.jp2" mimetype="image/jp2" objectId="druid:tm207xk5096" resourceId="tm207xk5096_1"/>
         #     <relationship objectId="druid:tm207xk5096" type="alsoAvailableAs"/>
         # Note: Only creating if published.
-        cocina_fileset.structural.contains.filter { |cocina_file| cocina_file.administrative.publish }.each do |cocina_file|
+        Array(cocina_fileset.dig('structural', 'contains')).filter { |cocina_file| cocina_file.dig('administrative', 'publish') }.each do |cocina_file|
           resource.add_child(Nokogiri::XML::Node.new('label', @xml_doc).tap { |tag| tag.content = label })
-          resource.add_child(create_external_file_node(cocina_file, cocina_fileset.externalIdentifier, external_druid))
+          resource.add_child(create_external_file_node(cocina_file, cocina_fileset['externalIdentifier'], external_druid))
         end
       end
 
       def create_external_file_node(cocina_file, resource_id, external_druid)
         Nokogiri::XML::Node.new('externalFile', @xml_doc).tap do |file_node|
-          file_node['fileId'] = cocina_file.filename
-          file_node['mimetype'] = cocina_file.hasMimeType
+          file_node['fileId'] = cocina_file['filename']
+          file_node['mimetype'] = cocina_file['hasMimeType']
           file_node['objectId'] = external_druid
           file_node['resourceId'] = resource_id
           # We are guarding for the presence of presentation here, however
           # all "good" external files should be images and have presentation.
-          if cocina_file.presentation
-            file_node.add_child(create_image_data_node(cocina_file.presentation.height, cocina_file.presentation.width))
+          if cocina_file['presentation']
+            file_node.add_child(create_image_data_node(cocina_file.dig('presentation', 'height'), cocina_file.dig('presentation', 'width')))
           else
             Honeybadger.notify('[Data Error] External resource has no presentation data', context: { external_druid: })
           end
@@ -174,7 +174,7 @@ module Cocina
       end
 
       def type_for(cocina_fileset)
-        cocina_fileset.type.delete_prefix('https://cocina.sul.stanford.edu/models/resources/').delete_suffix('.jsonld')
+        (cocina_fileset.is_a?(Hash) ? cocina_fileset['type'] : cocina_fileset.type).delete_prefix('https://cocina.sul.stanford.edu/models/resources/').delete_suffix('.jsonld')
       end
 
       def create_file_nodes(resource, cocina_fileset)

--- a/app/services/cocina/to_xml/content_metadata_generator.rb
+++ b/app/services/cocina/to_xml/content_metadata_generator.rb
@@ -173,8 +173,10 @@ module Cocina
         end
       end
 
+      # @param [Cocina::Object::DRO, Hash] cocina_fileset
+      # When a virtual object member and called from add_members_data,
+      # cocina_fileset will be a hash returned from CocinaObjectStore
       def type_for(cocina_fileset)
-        # When a virtual object member and called from add_members_data, will be a hash returned from CocinaObjectStore 
         (cocina_fileset.is_a?(Hash) ? cocina_fileset['type'] : cocina_fileset.type).delete_prefix('https://cocina.sul.stanford.edu/models/resources/').delete_suffix('.jsonld')
       end
 

--- a/app/services/cocina/to_xml/content_metadata_generator.rb
+++ b/app/services/cocina/to_xml/content_metadata_generator.rb
@@ -174,6 +174,7 @@ module Cocina
       end
 
       def type_for(cocina_fileset)
+        # When a virtual object member and called from add_members_data, will be a hash returned from CocinaObjectStore 
         (cocina_fileset.is_a?(Hash) ? cocina_fileset['type'] : cocina_fileset.type).delete_prefix('https://cocina.sul.stanford.edu/models/resources/').delete_suffix('.jsonld')
       end
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -4,7 +4,6 @@ class CocinaObjectStore
 
     raise "No cocina.json found for #{druid} in stacks or purl paths" unless stacks_path.exist?
 
-    data_hash = JSON.parse(File.read(stacks_path))
-    Cocina::Models.build(data_hash)
+    JSON.parse(File.read(stacks_path))
   end
 end

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -35,7 +35,7 @@ class PurlCocinaUpdater
       content_type: cocina_data.content_type,
       catkey: cocina_data.catkey,
       published_at: Time.current,
-      cocina_object:,
+      cocina_hash: cocina_object,
       version:,
       deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
     }

--- a/app/services/purl_cocina_updater.rb
+++ b/app/services/purl_cocina_updater.rb
@@ -11,12 +11,13 @@ class PurlCocinaUpdater
   # @param [Integer] version
   def initialize(active_record, cocina_object, version: nil)
     @active_record = active_record
-    @cocina_data = CocinaData.new(cocina_object)
+    @cocina_object = cocina_object
+    @cocina_data = CocinaData.new(cocina_object.to_h.deep_stringify_keys)
     @version = version
     Honeybadger.context({ cocina_object: cocina_object.to_h })
   end
 
-  attr_reader :active_record, :cocina_data, :version
+  attr_reader :active_record, :cocina_object, :cocina_data, :version
 
   delegate :collections, :constituents, to: :cocina_data
 
@@ -34,7 +35,7 @@ class PurlCocinaUpdater
       content_type: cocina_data.content_type,
       catkey: cocina_data.catkey,
       published_at: Time.current,
-      cocina_object: cocina_data.cocina_object,
+      cocina_object:,
       version:,
       deleted_at: nil # ensure the deleted at field is nil (important for a republish of a previously deleted purl)
     }

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -5,27 +5,27 @@ class ThumbnailService
   # allow the mimetype attribute to be lower or camelcase when searching to make it more robust
   MIME_TYPE = 'image/jp2'
 
-  # @param [Cocina::Model::DRO] object
+  # @param [Cocina::Models::DRO, Hash] object
   def initialize(object)
-    @object = object
+    data_hash = object.is_a?(Hash) ? object : object.to_h.deep_stringify_keys
+    @record = CocinaDisplay::CocinaRecord.new(data_hash)
   end
 
-  attr_reader :object
+  attr_reader :record
 
   # @return [String] the computed thumb filename, with the druid prefix and a slash in front of it, e.g. oo000oo0001/filenamewith space.jp2
   def thumb
-    return unless object.respond_to?(:structural) && object.structural
+    record.filesets.each do |file_set|
+      file_set.files.each do |file|
+        next unless file.mime_type == MIME_TYPE
 
-    object.structural.contains.each do |file_set|
-      file_set.structural.contains.each do |file|
-        next unless file.hasMimeType == MIME_TYPE
-
-        return "#{object.externalIdentifier.delete_prefix('druid:')}/#{file.filename}"
+        return "#{record.bare_druid}/#{file.filename}"
       end
     end
 
-    return if object.structural.hasMemberOrders.empty? || object.structural.hasMemberOrders.first.members.empty?
+    first_member = record.cocina_doc.dig('structural', 'hasMemberOrders', 0, 'members', 0)
+    return if first_member.blank?
 
-    self.class.new(CocinaObjectStore.find(object.structural.hasMemberOrders.first.members.first)).thumb
+    self.class.new(CocinaObjectStore.find(first_member)).thumb
   end
 end

--- a/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
@@ -899,7 +899,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
     end
 
     before do
-      allow(CocinaObjectStore).to receive(:find).with(constituent_druid).and_return(constituent_item)
+      allow(CocinaObjectStore).to receive(:find).with(constituent_druid).and_return(constituent_item.to_h.deep_stringify_keys)
     end
 
     it 'generates contentMetadata.xml' do

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe CocinaObjectStore do
         File.write("#{stacks_versions_path}/cocina.3.json", cocina_json)
       end
 
-      it 'returns a Cocina::Models::DROWithMetadata object' do
+      it 'returns the parsed cocina.json as a Hash' do
         result = described_class.find(druid)
-        expect(result).to be_a(Cocina::Models::DROWithMetadata)
+        expect(result).to be_a(Hash)
+        expect(result['externalIdentifier']).to eq(druid)
       end
     end
   end

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe Publish::PublicXmlService do
         end
 
         before do
-          allow(CocinaObjectStore).to receive(:find).and_return(build(:collection))
+          allow(CocinaObjectStore).to receive(:find).and_return(build(:collection).to_h.deep_stringify_keys)
         end
 
         it 'exports relationships' do
@@ -504,8 +504,8 @@ RSpec.describe Publish::PublicXmlService do
       end
 
       it 'handles externalFile references' do
-        allow(CocinaObjectStore).to receive(:find).with(cover_item.externalIdentifier).and_return(cover_item)
-        allow(CocinaObjectStore).to receive(:find).with(title_item.externalIdentifier).and_return(title_item)
+        allow(CocinaObjectStore).to receive(:find).with(cover_item.externalIdentifier).and_return(cover_item.to_h.deep_stringify_keys)
+        allow(CocinaObjectStore).to receive(:find).with(title_item.externalIdentifier).and_return(title_item.to_h.deep_stringify_keys)
         expect(ng_xml.at_xpath('/publicObject/contentMetadata').to_xml).to be_equivalent_to(expected_xml)
       end
     end

--- a/spec/services/purl_cocina_updater_spec.rb
+++ b/spec/services/purl_cocina_updater_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PurlCocinaUpdater do
     end
 
     it "updates the stored data" do
-      expect(purl.cocina_object).to eq cocina
+      expect(purl.cocina_object).to eq cocina.to_h.deep_stringify_keys
       expect(purl.public_json.data).to eq cocina.to_json
     end
 

--- a/spec/services/purl_cocina_updater_spec.rb
+++ b/spec/services/purl_cocina_updater_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PurlCocinaUpdater do
     end
 
     it "updates the stored data" do
-      expect(purl.cocina_object).to eq cocina.to_h.deep_stringify_keys
+      expect(purl.cocina_hash).to eq cocina.to_h.deep_stringify_keys
       expect(purl.public_json.data).to eq cocina.to_json
     end
 

--- a/spec/services/thumbnail_service_spec.rb
+++ b/spec/services/thumbnail_service_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe ThumbnailService do
         end
 
         before do
-          allow(CocinaObjectStore).to receive(:find).with(druid).and_return(member_object)
+          allow(CocinaObjectStore).to receive(:find).with(druid).and_return(member_object.to_h.deep_stringify_keys)
         end
 
         it 'returns the first image of the first member as the thumb' do


### PR DESCRIPTION
Stored public cocina can be invalid cocina. Building a Cocina::Models object from the stored JSON can raise `Cocina::Models::ValidationError`s. This will certainly be the case when we remove the top-level `label` property from the cocina-models schema. Public cocina was being read for virtual object members when the parent is being republished. 

This changes some locations that used a cocina object to work with a hash instead. `CocinaDisplay` is used where possible. 

There are a few locations where a Cocina object is still being built, but not from cocina on stacks. 
* Argo POSTs to `ModsController` to get back MODS XML when the "Download descriptive metadata as XML" bulk action is used. That is only used for a current Cocina object which should be valid. 
* A publish request that goes through `Publish::PublicCocinaGenerator.generate(cocina:)` is also still using a cocina object. That could be looked at further in another update if needed.
 
Claude assisted with the analysis and code. 

Tested by republishing the canonical virtual object and also republishing a virtual object where I edited the stored cocina of a member to be invalid. Also tested with integration tests that do normal publishing. 

